### PR TITLE
Update run-locally.md

### DIFF
--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -33,7 +33,7 @@ Once you confirmed that you have the prereqs ready, you can go ahead and install
 #### Main IP
 First of all, the installation command for local installation requires an extra parameter (`MAIN_NODE_IP_ADDRESS`)
 ```bash
-docker run -e MAIN_NODE_IP_ADDRESS='127.0.0.1' -p 80:80 -p 443:443 -p 3000:3000 -v /var/run/docker.sock:/var/run/docker.sock -v /captain:/captain caprover/caprover
+docker run -e MAIN_NODE_IP_ADDRESS=127.0.0.1 -p 80:80 -p 443:443 -p 3000:3000 -v /var/run/docker.sock:/var/run/docker.sock -v /captain:/captain caprover/caprover
 ```
 
 #### Setup


### PR DESCRIPTION
While trying to run CapRover locally, I realized that the quotes from the docs aren't removed, leading to failure at startup:
```
November 12th 2019, 8:59:28.551 pm    Starting swarm at '127.0.0.1':2377
Installation failed.
{ Error: (HTTP code 400) bad parameter - advertise address must be a non-zero IP address or network interface (with optional port number)
```

Works without:
```
November 12th 2019, 9:00:19.929 pm    Starting swarm at 127.0.0.1:2377
Swarm started: qhdqfgx5yie12eeqwxnn6wq7x
```