### PR TITLE
feat: add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -29,7 +29,13 @@ const siteConfig = {
   // For github.io type URLs, you would set the url and baseUrl like:
   //   url: 'https://facebook.github.io',
   //   baseUrl: '/test-site/',
-
+  
+  algolia: {
+    apiKey: '858cd5cd1997c06856239e8767b9461f',
+    indexName: 'captainduckduck',
+    algoliaOptions: {} // Optional, if provided by Algolia
+  },
+  
   // Used for publishing and more
   projectName: 'CapRover',
   organizationName: 'CapRover',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.