### PR TITLE
Add OhMyForm to the list of one-click apps

### DIFF
--- a/docs/one-click-apps.md
+++ b/docs/one-click-apps.md
@@ -45,6 +45,7 @@ There is a repository of [One Click Apps on GitHub](https://github.com/caprover/
 - NextCloud
 - Rainloop
 - Thumbor
+- OhMyForm
 - And many more...
 
 


### PR DESCRIPTION
See https://github.com/caprover/one-click-apps/pull/284. Idk if you want contributors to add everything here manually or if it's supposed to be just a list of some examples. I [proposed before](https://github.com/caprover/caprover/issues/863) to generate a human-readable list of available one-click apps from api data, but that was rejected. Anyways, keep up the good work :)