### PR TITLE
Fix captain config location and fix import

### DIFF
--- a/docs/pre-deploy-script.md
+++ b/docs/pre-deploy-script.md
@@ -22,12 +22,12 @@ var preDeployFunction = function (captainAppObj, dockerUpdateObject) {
 
 ```
 
-Note that `captainAppObj`, is the app object as saved in `/captain/config.conf` file, and `dockerUpdateObject` is the service update object that is being passed to Docker to update the service (environment vars, image version and etc). This object is as per [Docker docs](https://docs.docker.com/engine/api/v1.30/#operation/ServiceUpdate).
+Note that `captainAppObj`, is the app object as saved in `/captain/data/config-captain.json` file, and `dockerUpdateObject` is the service update object that is being passed to Docker to update the service (environment vars, image version and etc). This object is as per [Docker docs](https://docs.docker.com/engine/api/v1.30/#operation/ServiceUpdate).
 
 Since this script will be executed in CapRover process, you'll get access to all node dependecies that CapRover has, see [CaptainDuckDuck/app-backend/package.json](https://github.com/caprover/caprover/blob/master/package.json). For example, the following script injects a UUID mapped to the deployed version to service label with every update:
 
 ```
-var uuid = require('uuid/v4');
+var { v4: uuid } = require('uuid');
 
 var preDeployFunction = function (captainAppObj, dockerUpdateObject) {
 	return Promise.resolve()


### PR DESCRIPTION
I located the captain config file at `/captain/data/config-captain.json`.

Further, this script caused an error until the import format was changed.