### PR TITLE
Added information about the Git SHA to the environment varialbes documentation

### DIFF
--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -45,6 +45,14 @@ ARG BUCKET_NAME=${BUCKET_NAME}
 ARG SERVER_ENDPOINT=${SERVER_ENDPOINT}
 ```
 
+As well as the variables you set yourself, CapRover will also set a `CAPROVER_GIT_COMMIT_SHA` environment variable to the full git commit SHA that is being deployed. This is only available during the Docker build and is not available inside your app by default. If you want to use it inside your app then you can use something like the following:
+
+```
+FROM imagename....
+ARG CAPROVER_GIT_COMMIT_SHA=${CAPROVER_GIT_COMMIT_SHA}
+ENV CAPROVER_GIT_COMMIT_SHA=${CAPROVER_GIT_COMMIT_SHA}
+```
+
 ### Port Mapping
 
 CapRover allows you to map ports from a container to the host. You should use this feature if you want a specific port of your apps/containers to be publicly accessible. The most common use case is when you want to **connect to a database container from your local machine**.


### PR DESCRIPTION
Adds documentation for this change: https://github.com/caprover/caprover/pull/1049

Feel free to change this if you think there's a better way to explain it.