### PR TITLE
Added docs for Certbot and ACME servers

### DIFF
--- a/docs/certbot-config.md
+++ b/docs/certbot-config.md
@@ -1,0 +1,50 @@
+---
+id: certbot-config
+title: Configure Certbot to use a new ACME Server
+sidebar_label: Change ACME Server
+---
+
+## First step
+
+Normally, the directory `/captain/data/letsencrypt/etc` should contain the volume used by Certbot,
+to configure Certbot, add a `cli.ini` file in this directory:
+```
+$ cd /captain/data/letsencrypt/etc/
+$ nano cli.ini
+```
+
+## Configure the right things
+
+We will take as an example ZeroSSL's ACME server to guide you over the steps needed to make Certbot work correctly with it,
+
+first (at least for ZeroSSL, you need to get EAB credentials which are [here](https://app.zerossl.com/developer)) we add our email and we tell Certbot to accept the TOS of the service:
+```
+email = foo@example.com
+agree-tos = true
+```
+
+then we add the server (and if needed the EAB credentials):
+```
+server = https://acme.zerossl.com/v2/DV90 # (change it with your ACME server)
+eab-kid = some-short-string
+eab-hmac-key = a-big-key
+```
+
+## Restart certbot
+
+Then to apply our changes we need to update Certbot's service:
+```
+$ docker service update captain-certbot
+```
+
+And you're done !
+
+## CAA Record
+
+Remember to add a CAA record in your DNS to avoid any problem when generating SSL certs
+
+for example, ZeroSSL need you to have:
+```
+<your domain>. 3600 IN CAA 0 issue "sectigo.com"
+<your domain>. 3600 IN CAA 0 issuewild "sectigo.com"
+```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -18,7 +18,8 @@
       "app-scaling-and-cluster",
       "pre-deploy-script",
       "play-with-docker",
-      "run-locally"
+      "run-locally",
+      "certbot-config"
     ],
     "Recipes and Tips": [
       "sample-apps",


### PR DESCRIPTION
Hi !

I recently switched from let's Encrypt to ZeroSSL and because I searched for a while I decided to share how I did,
the change of ACME servers is possible with the `cli.ini` config that Certbot fetch when starting,
then I only used Certbot docs to change the default values (https://eff-certbot.readthedocs.io/en/stable/using.html#config-file)

I hope this helps !