### PR TITLE
"Nginx Proxy" -> "Nginx Reverse Proxy"

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -205,4 +205,4 @@ networks:
     external: true
 ```
 
-Now instead of potential port mapping that you might have, like `8080:80`, you can just create a CapRover "Nginx Proxy" app and use your container name as the upstream proxy, like `http://web-app` and done!
+Now instead of potential port mapping that you might have, like `8080:80`, you can just create a CapRover "Nginx Reverse Proxy" app and use your container name as the upstream proxy, like `http://web-app` and done!


### PR DESCRIPTION
I just used the "Alternative Approach" to using CapRover with docker-compose based installations. I was a bit confused because no "Nginx Proxy" caprover app existed, but found a caprover app called "Nginx Reverse Proxy" instead, and using that worked. Assuming it's a typo, here's a fix.