### PR TITLE
Add reference to tutorial to deploy Django app

### DIFF
--- a/docs/sample-apps.md
+++ b/docs/sample-apps.md
@@ -49,6 +49,8 @@ This project template aims to provide a more real-world Django template includin
 
 View the code and documentation on [GitLab](https://gitlab.com/kamneros/caprover-django)
 
+Additionaly, you can find a step by step tutorial to deploy your Django App to CapRover [here](https://blog.kenshuri.com/posts/006_from_heroku_to_capRover.md).
+
 #### CapRover Laravel
 
 - [jackbrycesmith/laravel-caprover-template](https://github.com/jackbrycesmith/laravel-caprover-template)


### PR DESCRIPTION
Following discussion on this [issue](https://github.com/caprover/caprover/issues/1507#issuecomment-1298028386), I added a reference to the tutorial I wrote to deploy a Django app.