### PR TITLE
fix: Updates SSH command to use PEM format

### DIFF
--- a/docs/deployment-methods.md
+++ b/docs/deployment-methods.md
@@ -28,7 +28,7 @@ This method is perhaps the most convenient one. This method automatically trigge
 - branch: The branch you want to be tracked, for example `master` or `staging` or `release`...
 - github/bitbucket username(email address): This is username that will be used when Captain downloads the repo.
 - github/bitbucket password: You can enter any non-empty text, like `123456`, for public projects.
-- Or, instead of username/password, use SSH Key: Make sure to use PEM format as other formats may not work. Use the following command if unsure: `ssh-keygen -t ed25519 -C "yourname@example.com" -f ./deploykey -q -N ""`.
+- Or, instead of username/password, use SSH Key: Make sure to use PEM format as other formats may not work. Use the following command if unsure: `ssh-keygen -t rsa -m PEM -C "yourname@example.com" -f ./deploykey -q -N ""`.
 
 After you enter this information, save your configuration. And go to your apps page again. Now, you'll see a new field call webhook. Simply copy this webhook to your github/bitbucket repo webhooks (see below). Captain listens to POST requests on this link and triggers a build.
 


### PR DESCRIPTION
The example command in the docs uses the OPENSSH format which is not supported by Caprover and leads to deployment issues. This PR updates the example comand to use the PEM format.