### PR TITLE
Clarify Docker registry credentials

### DIFF
--- a/docs/app-scaling-and-cluster.md
+++ b/docs/app-scaling-and-cluster.md
@@ -10,7 +10,7 @@ CapRover offers you multiple ways to scale up your app, running it on multiple p
 
 ## Run Multiple Instances of App:
 
-Your Pizza app is doing great and you are getting thousands of hits on your website. Having one instance of your app is not good enough. Your latency has gone up. Next thing you want is to consider to run multiple instances of your app on your Captain. You can do this from the Apps section of Captain web. Let's say you change your instance count to 3. Captain creates 3 instances of your app running at the same time. If any of them dies (crashes), it automatically spins off a new one! You always have 3 instances of your Pizza app running! The best part? Captain automatically spreads the requests between different instances of your app. 
+Your Pizza app is doing great and you are getting thousands of hits on your website. Having one instance of your app is not good enough. Your latency has gone up. Next thing you want is to consider to run multiple instances of your app on your Captain. You can do this from the Apps section of Captain web. Let's say you change your instance count to 3. Captain creates 3 instances of your app running at the same time. If any of them dies (crashes), it automatically spins off a new one! You always have 3 instances of your Pizza app running! The best part? Captain automatically spreads the requests between different instances of your app.
 
 ## Run Multiple Servers:
 
@@ -19,6 +19,7 @@ Wow! Your Pizza app is really popular! You have 3 instances of your app running 
 CapRover uses [Docker Swarm](https://docs.docker.com/engine/swarm/) under the hood. It provides an option to use CapRover UI to set up a cluster of nodes. Alternatively, you can use plain Docker Swarm commands `docker swarm join...` commands to set up your cluster. There is absolutely no difference between the two methods. The first method uses UI and the second method uses command line.
 
 At this point, you have to enter the following information:
+
 - CapRover IP Address (as seen by remote): this is the IP address of your original server
 - New node IP Address (as seen by Captain): this is the IP address of your second server
 - Private SSH key for `root` user: this is the SSH key from your CapRover server that will be used to SSH to your second server. On Linux, it's on `/home/yourusername/.ssh/id_rsa`
@@ -30,24 +31,22 @@ The leader node is a manager who's been elected as Leader. This is the node wher
 
 Note that only apps without "Persistent Data" can be scaled across nodes. Apps that have "Persistent Data" enabled will only run on 1 node.
 
-
 ### Default Push Registry:
 
 Default Push Docker Registry is a Docker Registry where your apps will be stored in as soon as you deploy them to server.
 
 For cluster mode (more than one server) you will need to have a default push Docker Registry.
 
-
 ### Setup Docker Registry:
 
 Docker Registry is simply the repository that different nodes in a cluster can access to download your app and run it. If only have one server (no cluster), there is pretty much no benefit to setting up Docker Registry.
 
 On the other hand, Docker Registry needs to be set up and ready for clusters. To setup Registry, simply go to your Captain web dashboard, select Cluster from the menu, and follow the instructions. You will be given two options:
+
 - Docker Registry managed by Captain.
 - Docker Registry managed by a 3rd party provider.
 
 For most cases, a Registry managed by Captain should be good enough. Note that before switching to cluster from a single node, if you have any existing app, you will have to setup Registry and re-deploy all your existing app to make sure they are pushed to the registry and are available to all nodes, not just the main leader node.
-
 
 ### More than one Registry:
 
@@ -55,15 +54,14 @@ You can be connected to more than one registry at a time. For example, you may b
 
 Having said that, you can only have one default push registry. This is the registry where images will be pushed to once they are built on the server.
 
-
 ### Disabling Registry:
 
 At any point in time, you have the option to:
+
 - Disable Registry
 - Delete Registry Auth Details
 
 However, note that if you have a cluster (more than one server), if you remove your docker registry your apps may misbehave.
-
 
 ### Add a Private Docker Registry:
 
@@ -72,6 +70,8 @@ If you need to pull images from a private docker registry such as ghcr.io or doc
 - Username: `<your github username>`
 - Password: [a personal token that you create](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) - make sure it has access to read packages at least.
 - Domain: `ghcr.io`
-- Image Prefix: `<your github username>`
-  
+- Image Prefix: `<your github username>` (MUST BE lowercase)
+
 If Docker images are stored as `your-username/your-image` then use your github username as the image prefix. Otherwise, if you have an organization in github where your images are stored as `my-org/my-image`, use `my-org` as your image prefix.
+
+You can setup your credentials under the **Cluster** menu. If you only intend to pull images, make sure to disable **Pushing New Images**

--- a/docs/ci-cd-integration/deploy-from-github.md
+++ b/docs/ci-cd-integration/deploy-from-github.md
@@ -150,6 +150,8 @@ Use these values:
 - Domain: `ghcr.io` (no www, no http)
 - Image Prefix: `<your github username or your org username>` (if you're pulling images from an org different than your username)
 
+> If your image prefix is your github username, your prefix MUST BE lowercase
+
 #### Create the GitHub Action
 
 GitHub Actions is the CI/CD pipeline built into GitHub. If you are unfamiliar with it, it would be beneficial to learn the basics by reviewing GitHub's Understanding GitHub Actions Docs: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions


### PR DESCRIPTION
This PR adds some context on how to setup the docker registry if you only intend to pull images.

It also highlights were to access the credential setup, and thus removes some ambiguity.

I created an issue for the original caprover repo by mistake, you can reference it:
https://github.com/caprover/caprover/issues/2269#issuecomment-2677001492