### PR TITLE
[Typo] Update captain-definition-file.md

### DIFF
--- a/docs/captain-definition-file.md
+++ b/docs/captain-definition-file.md
@@ -18,7 +18,7 @@ One of the key components of CapRover is the `captain-definition` file that sits
 
 `schemaVersion` is always 2. And `templateId` is the piece which defines the foundation you need in order to run your app. It is in `LANGUAGE/VERSION` format. LANGUAGE can be one of these: `node`, `php`, `python-django`, `ruby-rack`. And VERSION is the version of the language you want to use - see [below](#versions-for-templateid).
 
-Note that although the `templateId` can be one of the 4 most popular web app languages: NodeJS, PHP and Python/Django, Ruby/Rack, you are NOT LIMITED to these predefined languages! With CapRover, you have the ability to define your own Dockerfile. With a customized Dockerfile, you can deploy any laguage, Go, Java, .NET, you name it! Dockerfiles are quite easy to write. For example, the two captain-definition files below generate <b>the exact same result</b>.
+Note that although the `templateId` can be one of the 4 most popular web app languages: NodeJS, PHP and Python/Django, Ruby/Rack, you are NOT LIMITED to these predefined languages! With CapRover, you have the ability to define your own Dockerfile. With a customized Dockerfile, you can deploy any language, Go, Java, .NET, you name it! Dockerfiles are quite easy to write. For example, the two captain-definition files below generate <b>the exact same result</b>.
 
 #### Simple version
 


### PR DESCRIPTION
This PR corrects the spelling of `laguage` to `language` on https://caprover.com/docs/captain-definition-file.html