### PR TITLE
Fix gitlab personal access tokens link

### DIFF
--- a/docs/ci-cd-integration/deploy-from-gitlab.md
+++ b/docs/ci-cd-integration/deploy-from-gitlab.md
@@ -51,7 +51,7 @@ Add, commit and push this file.
 
 ### 4- Create an Access Token for CapRover
 
-CapRover needs to pull the built images from GitLab, so we need to create an access token. Navigate to https://gitlab.com/-/profile/personal_access_tokens and create a token.
+CapRover needs to pull the built images from GitLab, so we need to create an access token. Navigate to [User settings > Personal access tokens](https://gitlab.com/-/user_settings/personal_access_tokens) and create a token.
 
 Make sure to assign `read_registry` and `write_registry` permissions for this token.
 


### PR DESCRIPTION
Gitlab changed their PATs url from /profile/personal_access_tokens to /user_settings/personal_access_tokens.