### PR TITLE
Publish redesigned homepage

### DIFF
--- a/.github/workflows/website-publish.yml
+++ b/.github/workflows/website-publish.yml
@@ -3,15 +3,61 @@ name: Publish website
 on:
   push:
     branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-website
+  cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js for Docusaurus
+        uses: actions/setup-node@v5
         with:
           node-version: 10
-      - run: cd website && ls -la && npm i && npm run clean-build && ./publish-from-actions.sh
+
+      - name: Build existing website and documentation
+        working-directory: website
+        run: |
+          npm install
+          npm run clean-build
+
+      - name: Set up Node.js for homepage
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: homepage/package-lock.json
+
+      - name: Install homepage dependencies
+        working-directory: homepage
+        run: npm ci
+
+      - name: Lint homepage
+        working-directory: homepage
+        run: npm run lint
+
+      - name: Build and test homepage
+        working-directory: homepage
+        run: npm test
+
+      - name: Compose and verify combined site
+        run: node scripts/compose-site.mjs
+
+      - name: Smoke test combined site
+        run: node scripts/smoke-combined-site.mjs
+
+      - name: Publish combined site
+        working-directory: website
         env:
-          GITHUB_PERSONAL_TOKEN: ${{secrets.GITHUB_PERSONAL_TOKEN}}
+          BUILD_DIR: ${{ github.workspace }}/build/combined-site
+          GITHUB_PERSONAL_TOKEN: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
+        run: ./publish-from-actions.sh

--- a/website/publish-from-actions.sh
+++ b/website/publish-from-actions.sh
@@ -26,7 +26,9 @@
 
 set -e
 
-source ./build_dir
+if [ -z "${BUILD_DIR:-}" ]; then
+  source ./build_dir
+fi
 
 echo "#################################################"
 echo "Changing directory to 'BUILD_DIR' $BUILD_DIR ..."


### PR DESCRIPTION
## What changed

- update the production workflow to build the existing Docusaurus site with Node.js 10
- build, lint, and test the isolated Next.js homepage with Node.js 22
- compose the combined artifact using the preservation checks merged in #157
- smoke test the homepage, documentation, Next.js assets, and namespaced homepage assets before publishing
- publish the verified `build/combined-site` artifact through the existing `gh-pages` mechanism
- add manual dispatch and deployment concurrency protection
- update the existing publish script to accept an explicit build directory while preserving its legacy default

## Production impact

Merging this PR will replace only the root homepage at `https://caprover.com/`. Documentation and legacy assets remain sourced from the existing Docusaurus build. The current `CNAME`, `gh-pages` branch, and `GITHUB_PERSONAL_TOKEN` publishing mechanism are retained.

## Safety and rollback

Publishing does not begin unless both builds, static-export tests, composition integrity checks, and HTTP smoke tests pass. Reverting this PR restores the previous production workflow and old Docusaurus homepage.

## Validation

- production workflow YAML parsed successfully
- publish script passes `bash -n`
- combined artifact preserved 36 documentation files and 33 legacy image files
- `CNAME` preserved byte-for-byte as `caprover.com`
- combined HTTP smoke test passed for `/`, `/docs/get-started.html`, a generated Next.js asset, and the dashboard image
- the same clean-runner integration workflow passed in #157