### PR TITLE
Fix GitHub Pages publishing for the redesigned homepage

### DIFF
--- a/.github/workflows/website-publish.yml
+++ b/.github/workflows/website-publish.yml
@@ -3,15 +3,61 @@ name: Publish website
 on:
   push:
     branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-website
+  cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js for Docusaurus
+        uses: actions/setup-node@v5
         with:
           node-version: 10
-      - run: cd website && ls -la && npm i && npm run clean-build && ./publish-from-actions.sh
+
+      - name: Build existing website and documentation
+        working-directory: website
+        run: |
+          npm install
+          npm run clean-build
+
+      - name: Set up Node.js for homepage
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: homepage/package-lock.json
+
+      - name: Install homepage dependencies
+        working-directory: homepage
+        run: npm ci
+
+      - name: Lint homepage
+        working-directory: homepage
+        run: npm run lint
+
+      - name: Build and test homepage
+        working-directory: homepage
+        run: npm test
+
+      - name: Compose and verify combined site
+        run: node scripts/compose-site.mjs
+
+      - name: Smoke test combined site
+        run: node scripts/smoke-combined-site.mjs
+
+      - name: Publish combined site
+        working-directory: website
         env:
-          GITHUB_PERSONAL_TOKEN: ${{secrets.GITHUB_PERSONAL_TOKEN}}
+          BUILD_DIR: ${{ github.workspace }}/build/combined-site
+          GITHUB_PERSONAL_TOKEN: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
+        run: ./publish-from-actions.sh

--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -8,6 +8,7 @@ import {
   readdir,
   rm,
   stat,
+  writeFile,
 } from "node:fs/promises";
 import path from "node:path";
 
@@ -90,6 +91,8 @@ await cp(
   path.join(combinedSite, "homepage-assets"),
   { recursive: true },
 );
+await writeFile(path.join(combinedSite, ".nojekyll"), "");
+await requirePath(path.join(combinedSite, ".nojekyll"));
 
 const [docsAfter, imagesAfter, combinedCname, homepageHtml] = await Promise.all([
   snapshot(path.join(combinedSite, "docs")),

--- a/scripts/smoke-combined-site.mjs
+++ b/scripts/smoke-combined-site.mjs
@@ -50,6 +50,7 @@ try {
   assert(nextAsset, "Homepage does not reference a Next.js CSS or JavaScript asset");
 
   const checks = await Promise.all([
+    fetch(`${origin}/.nojekyll`),
     fetch(`${origin}/docs/get-started.html`),
     fetch(`${origin}/homepage-assets/caprover-dashboard.png`),
     fetch(`${origin}${nextAsset}`),
@@ -59,9 +60,10 @@ try {
     assert.equal(response.status, 200, `${response.url} did not return HTTP 200`);
   }
 
-  const docs = await checks[0].text();
+  assert.equal(await checks[0].text(), "", ".nojekyll must be empty");
+  const docs = await checks[1].text();
   assert.match(docs, /Getting Started/i);
-  assert(Number(checks[1].headers.get("content-length") ?? 0) > 0 || (await checks[1].arrayBuffer()).byteLength > 0);
+  assert(Number(checks[2].headers.get("content-length") ?? 0) > 0 || (await checks[2].arrayBuffer()).byteLength > 0);
 
   console.log("Combined site HTTP smoke test passed");
 } finally {

--- a/website/publish-from-actions.sh
+++ b/website/publish-from-actions.sh
@@ -26,7 +26,9 @@
 
 set -e
 
-source ./build_dir
+if [ -z "${BUILD_DIR:-}" ]; then
+  source ./build_dir
+fi
 
 echo "#################################################"
 echo "Changing directory to 'BUILD_DIR' $BUILD_DIR ..."


### PR DESCRIPTION
## What changed

- restores the combined legacy documentation + redesigned homepage production workflow
- creates an empty `.nojekyll` file in the composed site root
- verifies `.nojekyll`, documentation, homepage images, and a referenced `/_next/` asset in the combined-site smoke test
- preserves the existing `gh-pages` publishing mechanism and custom-domain `CNAME`

## Root cause

The previous deployment contained the Next.js `_next` directory, but it did not contain a root-level `.nojekyll` file. Branch-based GitHub Pages therefore processed the deployment with Jekyll, which excludes underscore-prefixed directories. The homepage HTML was served while its CSS, JavaScript, and fonts under `/_next/` were unavailable.

The earlier smoke test served the raw composed directory and did not assert the Pages bypass marker, so it could not catch that production-specific behavior.

## Validation

- confirmed the branch is based on the post-revert `master`
- compared the branch against `master`: only the production workflow, publisher override, composer, and smoke test changed
- PR workflow builds both sites and runs the combined-site smoke test
