### PR TITLE
Fix documentation theme regressions

### DIFF
--- a/docs/cdd-migration.md
+++ b/docs/cdd-migration.md
@@ -13,7 +13,7 @@ Simply run [this script](https://raw.githubusercontent.com/caprover/caprover/mas
 
 To migrate, you can simply run the following lines:
 
-```
+```bash
 wget https://raw.githubusercontent.com/caprover/caprover/master/dev-scripts/migrate-from-cdd.sh
 
 chmod +x migrate-from-cdd.sh

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -70,7 +70,7 @@ const siteConfig = {
 
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks
-    theme: "default",
+    theme: "atom-one-dark",
   },
 
   // Add custom scripts here that would be placed in <script> tags

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -38,6 +38,7 @@ a:hover {
 
 /* Header */
 .fixedHeaderContainer {
+  height: 78px;
   min-height: 78px;
   background: #fff;
   border-bottom: 1px solid #eef2f6;
@@ -46,7 +47,8 @@ a:hover {
 }
 
 .fixedHeaderContainer header {
-  min-height: 78px;
+  align-items: center;
+  min-height: 61px;
 }
 
 .fixedHeaderContainer header img {
@@ -133,6 +135,22 @@ a:hover {
 /* Documentation content */
 .mainContainer {
   color: var(--caprover-ink);
+}
+
+@media only screen and (min-width: 1024px) {
+  .navPusher {
+    padding-top: 78px;
+  }
+
+  .docsNavContainer {
+    height: calc(100vh - 78px);
+    top: 78px;
+  }
+
+  .onPageNav {
+    max-height: calc(100vh - 118px);
+    top: 118px;
+  }
 }
 
 .post h1,
@@ -281,9 +299,21 @@ code {
 }
 
 @media only screen and (max-width: 1023px) {
-  .fixedHeaderContainer,
-  .fixedHeaderContainer header {
+  .fixedHeaderContainer {
+    height: 68px;
     min-height: 68px;
+  }
+
+  .fixedHeaderContainer header {
+    min-height: 51px;
+  }
+
+  .navPusher {
+    padding-top: 118px;
+  }
+
+  .singleRowMobileNav.navPusher {
+    padding-top: 68px;
   }
 
   .navigationSlider .slidingNav ul {


### PR DESCRIPTION
## What changed

- restores the intended 78px desktop and 68px mobile documentation header heights
- updates the content, sidebar, and on-page navigation offsets so content starts below the fixed header with its normal padding
- switches Highlight.js from the light `default` palette to the dark-compatible `atom-one-dark` palette
- marks the CaptainDuckDuck migration command block as Bash so Highlight.js no longer misclassifies fragments such as `s:` in `https:`

## Root cause

PR #162 increased both the fixed header and its inner header to 78px without accounting for Docusaurus's existing vertical header padding. The rendered header became 94px while the page remained offset by 50px, hiding the content's top padding behind the fixed header.

The same PR introduced dark code-block backgrounds but retained Highlight.js's light syntax theme. Unlabeled code blocks were also auto-detected, which produced incorrect and low-contrast token colors.

## Validation

- `git diff --check`
- Docusaurus production build
- verified the generated migration page references `atom-one-dark.min.css`
- verified the generated migration block is identified as Bash and no longer contains the incorrectly highlighted `s:` token

The existing build still reports non-fatal missing optional image-optimizer binary warnings, then completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting for bash and Dockerfile command examples in the migration guide.

* **Style**
  * Updated code syntax highlighting with a darker Atom One theme.
  * Improved header sizing, spacing, and alignment across desktop and mobile layouts.
  * Adjusted documentation navigation and page spacing to better accommodate responsive header heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->