### PR TITLE
Add CapRover comparison hub and matchup pages

### DIFF
--- a/homepage/app/compare/comparison.css
+++ b/homepage/app/compare/comparison.css
@@ -1,0 +1,57 @@
+:root{--compare-blue:#155eef;--compare-blue-dark:#0b3b91;--compare-blue-soft:#eaf2ff;--compare-ink:#101828;--compare-muted:#667085;--compare-line:#d0d5dd;--compare-night:#071426}
+.compare-page{min-height:100vh;background:#fff;color:var(--compare-ink)}
+.compare-shell{width:min(1180px,calc(100% - 96px));margin:0 auto}
+.compare-header{height:78px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid #eef2f6}
+.compare-logo{display:flex;align-items:center;gap:11px;font-size:23px;font-weight:750;letter-spacing:-.04em}
+.compare-logo img{width:40px;height:40px;object-fit:contain}
+.compare-header-links{display:flex;gap:30px;align-items:center}
+.compare-header-links a{font-size:14px;font-weight:650;color:#344054}
+.compare-header-links a:hover,.source-links a:hover{color:var(--compare-blue)}
+.compare-hero{padding:110px 0 70px;max-width:1050px}
+.compare-kicker{font-size:12px;font-weight:850;letter-spacing:.14em;color:var(--compare-blue);margin:0 0 20px}
+.compare-hero h1{font-size:64px;line-height:1.03;letter-spacing:-.055em;margin:0;max-width:980px}
+.compare-lead{font-size:20px;line-height:1.65;color:#475467;max-width:900px;margin:28px 0 0}
+.verdict{margin-top:40px;padding:24px 28px;border:1px solid #bfd2f2;border-radius:14px;background:linear-gradient(145deg,#edf4ff,#fff)}
+.verdict strong{display:block;font-size:13px;color:var(--compare-blue);text-transform:uppercase;letter-spacing:.1em}
+.verdict p{font-size:17px;line-height:1.65;margin:10px 0 0;color:#344054}
+.compare-section{padding:70px 0}
+.compare-soft{background:#f6f9fe}
+.method-note{border-left:4px solid var(--compare-blue);background:var(--compare-blue-soft);padding:22px 26px;margin-bottom:34px;border-radius:0 10px 10px 0}
+.method-note strong{font-size:15px}.method-note p{margin:8px 0 0;color:#475467;line-height:1.6}
+.comparison-table-wrap,.two-column-table-wrap{overflow-x:auto;border:1px solid var(--compare-line);border-radius:14px;box-shadow:0 12px 36px #155eef0b}
+.comparison-table,.two-column-table{border-collapse:collapse;width:100%;min-width:900px;background:#fff}
+.comparison-table th,.comparison-table td,.two-column-table th,.two-column-table td{padding:17px 18px;text-align:left;border-right:1px solid #e4e7ec;border-bottom:1px solid #e4e7ec;font-size:14px;line-height:1.45;vertical-align:top}
+.comparison-table thead th,.two-column-table thead th{background:var(--compare-night);color:#fff;font-size:13px;letter-spacing:.025em}
+.comparison-table tbody th,.two-column-table tbody th{font-weight:750;width:20%;background:#fbfcfe}
+.comparison-table .is-focus{background:#f0f5ff}
+.comparison-table thead .is-focus{background:var(--compare-blue)}
+.comparison-table tr:last-child>* ,.two-column-table tr:last-child>*{border-bottom:0}
+.comparison-table tr>*:last-child,.two-column-table tr>*:last-child{border-right:0}
+.prose-grid{display:grid;grid-template-columns:1fr 1fr;gap:90px;align-items:start}
+.prose-grid h2,.compare-heading h2,.compare-section>h2,.source-links h2,.article-layout h2{font-size:42px;letter-spacing:-.04em;line-height:1.12;margin:0}
+.prose-copy p,.compare-heading>p,.article-layout p,.migration-grid p{color:#475467;line-height:1.75;font-size:16px;margin-top:0}
+.compare-heading{max-width:780px;margin-bottom:38px}
+.compare-heading>p{margin-top:18px}
+.matchup-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+.matchup-card{display:block;border:1px solid #d3deed;border-radius:15px;padding:30px;background:#fff;transition:.2s;min-height:235px}
+.matchup-card:hover{transform:translateY(-3px);border-color:#9bbbf1;box-shadow:0 18px 44px #155eef13}
+.matchup-card span{font-size:10px;letter-spacing:.13em;font-weight:850;color:var(--compare-blue)}
+.matchup-card h3{font-size:22px;margin:20px 0 10px}.matchup-card p{color:var(--compare-muted);line-height:1.6}.matchup-card b{display:block;margin-top:22px;color:var(--compare-blue);font-size:14px}
+.article-layout{display:grid;grid-template-columns:1fr 1fr;gap:44px 70px}
+.article-layout article{background:#fff;border:1px solid #dbe3ef;border-radius:14px;padding:34px}
+.article-layout h2{font-size:28px;margin-bottom:18px}
+.article-layout p:last-child{margin-bottom:0}
+.choice-grid{display:grid;grid-template-columns:1fr 1fr;gap:22px}
+.choice-grid article{border:1px solid #d3deed;border-radius:15px;padding:34px;background:#fff}
+.choice-grid ul{padding-left:22px;margin:0}.choice-grid li{padding:7px 0;color:#475467;line-height:1.55}
+.migration-grid{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:28px}
+.migration-grid p{border:1px solid #dbe3ef;border-radius:12px;padding:27px;margin:0}
+.source-links{margin-top:64px;border-top:1px solid #d9e2ef;padding-top:48px}
+.source-links h2{font-size:30px}.source-links>p{color:var(--compare-muted)}
+.source-links ul{columns:2;padding-left:20px}.source-links li{break-inside:avoid;margin:9px 0;color:#475467}.source-links a{text-decoration:underline;text-decoration-color:#b8c8df;text-underline-offset:3px}
+.compare-footer{border-top:1px solid #d9e2ef;padding:42px 0;margin-top:40px}
+.compare-footer-grid{display:grid;grid-template-columns:1fr 1fr 1fr auto;align-items:center;gap:24px}
+.compare-footer p,.compare-footer small{color:var(--compare-muted);font-size:13px}.compare-footer-grid>div{display:flex;gap:22px;font-size:14px;font-weight:650}
+@media(max-width:900px){.compare-shell{width:calc(100% - 48px)}.compare-hero h1{font-size:49px}.prose-grid,.article-layout{grid-template-columns:1fr}.matchup-grid{grid-template-columns:1fr}.compare-footer-grid{grid-template-columns:1fr 1fr}.source-links ul{columns:1}}
+@media(max-width:640px){.compare-shell{width:calc(100% - 32px)}.compare-header{height:68px}.compare-header-links a:first-child{display:none}.compare-header-links{gap:18px}.compare-logo{font-size:20px}.compare-logo img{width:34px;height:34px}.compare-hero{padding:75px 0 42px}.compare-hero h1{font-size:39px}.compare-lead{font-size:17px}.compare-section{padding:48px 0}.choice-grid,.migration-grid{grid-template-columns:1fr}.article-layout{gap:20px}.article-layout article{padding:26px 22px}.prose-grid h2,.compare-heading h2,.compare-section>h2{font-size:34px}.compare-footer-grid{grid-template-columns:1fr}.comparison-table th,.comparison-table td,.two-column-table th,.two-column-table td{padding:14px}}
+@media(prefers-reduced-motion:reduce){.matchup-card{transition:none}}

--- a/homepage/app/compare/components.tsx
+++ b/homepage/app/compare/components.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from "react";
+import { comparisonRows, products, type ComparisonRow, type Product, verifiedDate } from "./data";
+
+const DOCS = "https://caprover.com/docs/get-started.html";
+const GITHUB = "https://github.com/caprover/caprover";
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+const ASSET_PATH = "/homepage-assets";
+
+export function internal(path: string) {
+  return `${BASE_PATH}${path}`;
+}
+
+function Logo() {
+  return (
+    <a className="compare-logo" href={internal("/")} aria-label="CapRover home">
+      <img src={`${BASE_PATH}${ASSET_PATH}/caprover-logo.png`} alt="" aria-hidden="true" />
+      <span>CapRover</span>
+    </a>
+  );
+}
+
+export function CompareHeader() {
+  return (
+    <header className="compare-header compare-shell">
+      <Logo />
+      <div className="compare-header-links" role="navigation" aria-label="Comparison navigation">
+        <a href={internal("/compare/")}>Comparison hub</a>
+        <a href={DOCS}>Docs</a>
+        <a href={GITHUB}>GitHub</a>
+      </div>
+    </header>
+  );
+}
+
+export function CompareFooter() {
+  return (
+    <footer className="compare-footer">
+      <div className="compare-shell compare-footer-grid">
+        <Logo />
+        <p>Scalable, free, and self-hosted PaaS.</p>
+        <div><a href={DOCS}>Get started</a><a href={GITHUB}>GitHub</a></div>
+        <small>Last verified {verifiedDate}</small>
+      </div>
+    </footer>
+  );
+}
+
+export function PageHero({
+  eyebrow,
+  title,
+  intro,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  children?: ReactNode;
+}) {
+  return (
+    <section className="compare-hero compare-shell">
+      <p className="compare-kicker">{eyebrow}</p>
+      <h1>{title}</h1>
+      <p className="compare-lead">{intro}</p>
+      {children}
+    </section>
+  );
+}
+
+export function ComparisonTable({
+  rows = comparisonRows,
+  focus,
+}: {
+  rows?: ComparisonRow[];
+  focus?: Product;
+}) {
+  return (
+    <div className="comparison-table-wrap">
+      <table className="comparison-table">
+        <thead>
+          <tr>
+            <th scope="col">Capability</th>
+            {products.map((product) => (
+              <th scope="col" className={product.key === focus ? "is-focus" : ""} key={product.key}>
+                {product.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.feature}>
+              <th scope="row">{row.feature}</th>
+              {products.map((product) => (
+                <td className={product.key === focus ? "is-focus" : ""} key={product.key}>
+                  {row[product.key]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function ComparisonPrinciples() {
+  return (
+    <aside className="method-note">
+      <strong>How this comparison is maintained</strong>
+      <p>
+        Capability names are deliberately narrow. “Partial” means a useful subset exists, not that
+        the products are equivalent. Plugin-based and manual approaches are identified instead of
+        receiving an unexplained checkmark. Claims are based on official product documentation and
+        are dated because these projects change quickly.
+      </p>
+    </aside>
+  );
+}
+
+export function MatchupLinks({ current }: { current?: Product }) {
+  const links: Array<{ key: Product; label: string; path: string; text: string }> = [
+    { key: "coolify", label: "CapRover vs Coolify", path: "/compare/coolify/", text: "Compare architecture, deployment workflows and operations." },
+    { key: "dokploy", label: "CapRover vs Dokploy", path: "/compare/dokploy/", text: "Compare two Docker and Swarm-oriented control planes." },
+    { key: "dokku", label: "CapRover vs Dokku", path: "/compare/dokku/", text: "Compare dashboard-driven and CLI-first approaches." },
+  ];
+
+  return (
+    <div className="matchup-grid">
+      {links.filter((link) => link.key !== current).map((link) => (
+        <a className="matchup-card" href={internal(link.path)} key={link.key}>
+          <span>DETAILED COMPARISON</span>
+          <h3>{link.label}</h3>
+          <p>{link.text}</p>
+          <b>Read comparison →</b>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export function ChoiceGrid({
+  caprover,
+  competitorName,
+  competitor,
+}: {
+  caprover: string[];
+  competitorName: string;
+  competitor: string[];
+}) {
+  return (
+    <div className="choice-grid">
+      <article>
+        <p className="compare-kicker">CHOOSE CAPROVER IF</p>
+        <ul>{caprover.map((item) => <li key={item}>{item}</li>)}</ul>
+      </article>
+      <article>
+        <p className="compare-kicker">CHOOSE {competitorName.toUpperCase()} IF</p>
+        <ul>{competitor.map((item) => <li key={item}>{item}</li>)}</ul>
+      </article>
+    </div>
+  );
+}
+
+export function SourceLinks({ children }: { children: ReactNode }) {
+  return <div className="source-links"><h2>Sources and verification</h2><p>Last verified {verifiedDate}. Links below point to official project documentation.</p><ul>{children}</ul></div>;
+}
+
+export function ComparePage({ children }: { children: ReactNode }) {
+  return <main className="compare-page"><CompareHeader />{children}<CompareFooter /></main>;
+}

--- a/homepage/app/compare/components.tsx
+++ b/homepage/app/compare/components.tsx
@@ -111,7 +111,8 @@ export function ComparisonPrinciples() {
         Capability names are deliberately narrow. “Partial” means a useful subset exists, not that
         the products are equivalent. Plugin-based and manual approaches are identified instead of
         receiving an unexplained checkmark. Claims are based on official product documentation and
-        are dated because these projects change quickly.
+        are dated because these projects change quickly. Unless a row says otherwise, the scope
+        is the current self-hosted open-source edition; paid or enterprise additions are named.
       </p>
     </aside>
   );

--- a/homepage/app/compare/coolify/page.tsx
+++ b/homepage/app/compare/coolify/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import {
+  ChoiceGrid,
+  ComparePage,
+  ComparisonPrinciples,
+  MatchupLinks,
+  PageHero,
+  SourceLinks,
+} from "../components";
+
+export const metadata: Metadata = {
+  title: "CapRover vs Coolify: Self-Hosted PaaS Comparison",
+  description:
+    "Compare CapRover and Coolify across architecture, Docker Compose, Git deployment, networking, clustering, rollback and operational control.",
+  alternates: { canonical: "https://caprover.com/compare/coolify/" },
+};
+
+const rows = [
+  ["Primary operating model", "One CapRover installation managing a Docker Swarm", "A control plane managing connected Docker servers over SSH"],
+  ["Default proxy", "NGINX", "Traefik, with Caddy also supported"],
+  ["Docker Compose", "Partial parser for common fields", "First-class application and service support"],
+  ["Git deployment", "Generic Git credentials, SSH keys and webhooks", "Provider integrations, deploy keys and webhooks"],
+  ["Multi-node applications", "Docker Swarm replicas", "Standalone servers or Docker Swarm"],
+  ["Proxy customization", "Per-app NGINX template editor", "Proxy configuration, labels and raw Compose"],
+  ["Local registry", "CapRover can provision and manage one", "Can be deployed as a service or supplied externally"],
+  ["Platform backup", "Downloadable configuration backup", "Scheduled or manual instance backup"],
+];
+
+export default function CoolifyComparison() {
+  return (
+    <ComparePage>
+      <PageHero
+        eyebrow="CAPROVER VS COOLIFY"
+        title="Docker-native simplicity or a broader application platform?"
+        intro="CapRover and Coolify both run applications on infrastructure you control. CapRover stays close to Docker Swarm and NGINX, while Coolify provides a broader resource model with first-class Compose, projects, environments and Git-provider workflows."
+      >
+        <div className="verdict"><strong>Short answer</strong><p>Choose CapRover when you value a compact application model, NGINX control and a Swarm-first path from one server to several. Choose Coolify when Compose, multiple independent servers, preview deployments and team workflows are central requirements.</p></div>
+      </PageHero>
+
+      <section className="compare-section compare-shell">
+        <ComparisonPrinciples />
+        <div className="two-column-table-wrap">
+          <table className="two-column-table">
+            <thead><tr><th>Area</th><th>CapRover</th><th>Coolify</th></tr></thead>
+            <tbody>{rows.map(([area, caprover, coolify]) => <tr key={area}><th>{area}</th><td>{caprover}</td><td>{coolify}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="compare-section compare-soft">
+        <div className="compare-shell article-layout">
+          <article>
+            <h2>Architecture</h2>
+            <p>CapRover installs its control plane, NGINX and certificate services on a Docker Swarm manager. Additional nodes join that Swarm, and stateless replicas can be distributed across it. Persistent applications are pinned to a node unless their storage is externalized.</p>
+            <p>Coolify separates its control plane from connected deployment servers. It uses SSH to build and operate Docker resources on those servers. This makes independent-server management a natural part of its model, while Docker Swarm remains available when workloads need a cluster.</p>
+          </article>
+          <article>
+            <h2>Deployment workflow</h2>
+            <p>CapRover accepts local CLI deployments, dashboard uploads, Git webhooks, Dockerfiles and prebuilt images. Its captain-definition file gives the deployment a small, explicit contract. GitHub, GitLab, Bitbucket and other Git-compatible services can trigger deployments without requiring a provider-specific application.</p>
+            <p>Coolify invests more heavily in source integrations and build choices. It supports Docker Compose directly and offers Nixpacks, Railpack, Dockerfile and static builds. This is more flexible for repositories that already treat Compose as their deployment definition.</p>
+          </article>
+          <article>
+            <h2>Networking and control</h2>
+            <p>CapRover's main distinction is editable NGINX configuration. Operators can change an individual application's generated NGINX template or override the global template for newly created applications. Advanced container behavior can be expressed through Docker's ServiceUpdate schema.</p>
+            <p>Coolify uses Traefik by default and supports Caddy. Routing is managed through domains, proxy configuration and generated labels. Raw Compose provides an escape hatch when an operator wants to own the complete Compose definition and proxy labels.</p>
+          </article>
+          <article>
+            <h2>Operations</h2>
+            <p>Both products provide HTTPS automation, application logs, health checks, rollbacks, backups of platform state and monitoring. CapRover's backup intentionally excludes application images and persistent volumes. Coolify likewise distinguishes control-plane backups from workload data, databases and volumes.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="compare-section compare-shell">
+        <ChoiceGrid
+          caprover={[
+            "You prefer NGINX and want to edit its per-app configuration in the dashboard.",
+            "Your scaling model is a Docker Swarm cluster rather than several unrelated hosts.",
+            "You want a small application abstraction with direct Docker escape hatches.",
+            "Local CLI deployment and a platform-managed registry are valuable.",
+          ]}
+          competitorName="Coolify"
+          competitor={[
+            "Full Docker Compose compatibility is a primary requirement.",
+            "You want one control plane for multiple independent servers.",
+            "Projects, environments, preview deployments and team roles are important.",
+            "You prefer deeper source-provider and build-pack workflows.",
+          ]}
+        />
+      </section>
+
+      <section className="compare-section compare-shell">
+        <h2>Migration considerations</h2>
+        <div className="migration-grid">
+          <p><strong>Moving to CapRover:</strong> convert Compose services into CapRover applications or a compatible One-Click template, map domains and environment variables, and migrate persistent data separately.</p>
+          <p><strong>Moving to Coolify:</strong> recreate resources and source connections, translate CapRover settings into applications or Compose, and move databases and volumes using workload-specific backup tools.</p>
+        </div>
+      </section>
+
+      <section className="compare-section compare-shell">
+        <MatchupLinks current="coolify" />
+        <SourceLinks>
+          <li><a href="https://caprover.com/docs/app-scaling-and-cluster.html">CapRover scaling and clusters</a></li>
+          <li><a href="https://caprover.com/docs/nginx-customization.html">CapRover NGINX customization</a></li>
+          <li><a href="https://caprover.com/docs/deployment-methods.html">CapRover deployment methods</a></li>
+          <li><a href="https://coolify.io/docs">Coolify product documentation</a></li>
+          <li><a href="https://coolify.io/docs/applications/build-packs/docker-compose">Coolify Docker Compose deployments</a></li>
+          <li><a href="https://coolify.io/docs/knowledge-base/how-to/backup-restore-coolify">Coolify backup and restore</a></li>
+        </SourceLinks>
+      </section>
+    </ComparePage>
+  );
+}

--- a/homepage/app/compare/coolify/page.tsx
+++ b/homepage/app/compare/coolify/page.tsx
@@ -61,12 +61,12 @@ export default function CoolifyComparison() {
           </article>
           <article>
             <h2>Networking and control</h2>
-            <p>CapRover's main distinction is editable NGINX configuration. Operators can change an individual application's generated NGINX template or override the global template for newly created applications. Advanced container behavior can be expressed through Docker's ServiceUpdate schema.</p>
+            <p>CapRover’s main distinction is editable NGINX configuration. Operators can change an individual application’s generated NGINX template or override the global template for newly created applications. Advanced container behavior can be expressed through Docker’s ServiceUpdate schema.</p>
             <p>Coolify uses Traefik by default and supports Caddy. Routing is managed through domains, proxy configuration and generated labels. Raw Compose provides an escape hatch when an operator wants to own the complete Compose definition and proxy labels.</p>
           </article>
           <article>
             <h2>Operations</h2>
-            <p>Both products provide HTTPS automation, application logs, health checks, rollbacks, backups of platform state and monitoring. CapRover's backup intentionally excludes application images and persistent volumes. Coolify likewise distinguishes control-plane backups from workload data, databases and volumes.</p>
+            <p>Both products provide HTTPS automation, application logs, health checks, rollbacks, backups of platform state and monitoring. CapRover’s backup intentionally excludes application images and persistent volumes. Coolify likewise distinguishes control-plane backups from workload data, databases and volumes.</p>
           </article>
         </div>
       </section>

--- a/homepage/app/compare/coolify/page.tsx
+++ b/homepage/app/compare/coolify/page.tsx
@@ -17,13 +17,13 @@ export const metadata: Metadata = {
 
 const rows = [
   ["Primary operating model", "One CapRover installation managing a Docker Swarm", "A control plane managing connected Docker servers over SSH"],
-  ["Default proxy", "NGINX", "Traefik, with Caddy also supported"],
+  ["Default proxy", "NGINX", "Traefik; Caddy is also available but experimental"],
   ["Docker Compose", "Partial parser for common fields", "First-class application and service support"],
   ["Git deployment", "Generic Git credentials, SSH keys and webhooks", "Provider integrations, deploy keys and webhooks"],
   ["Multi-node applications", "Docker Swarm replicas", "Standalone servers or Docker Swarm"],
   ["Proxy customization", "Per-app NGINX template editor", "Proxy configuration, labels and raw Compose"],
   ["Local registry", "CapRover can provision and manage one", "Can be deployed as a service or supplied externally"],
-  ["Platform backup", "Downloadable configuration backup", "Scheduled or manual instance backup"],
+  ["Platform backup", "Dashboard download; restore during installation", "Scheduled S3 or manual instance backup"],
 ];
 
 export default function CoolifyComparison() {
@@ -66,7 +66,7 @@ export default function CoolifyComparison() {
           </article>
           <article>
             <h2>Operations</h2>
-            <p>Both products provide HTTPS automation, application logs, health checks, rollbacks, backups of platform state and monitoring. CapRover’s backup intentionally excludes application images and persistent volumes. Coolify likewise distinguishes control-plane backups from workload data, databases and volumes.</p>
+            <p>Both products provide HTTPS automation, application logs, rollback paths, platform-state backups and monitoring options. Coolify exposes health-check settings directly; CapRover users can define Docker health checks in the image or through a ServiceUpdate override. CapRover’s standard backup excludes application images and persistent volumes, although images in its self-hosted registry are included. Coolify likewise distinguishes control-plane backups from workload data, databases and volumes.</p>
           </article>
         </div>
       </section>

--- a/homepage/app/compare/data.ts
+++ b/homepage/app/compare/data.ts
@@ -1,0 +1,119 @@
+export type Product = "caprover" | "dokploy" | "dokku" | "coolify";
+
+export type ComparisonRow = {
+  feature: string;
+  caprover: string;
+  dokploy: string;
+  dokku: string;
+  coolify: string;
+};
+
+export const products: Array<{ key: Product; label: string }> = [
+  { key: "caprover", label: "CapRover" },
+  { key: "dokploy", label: "Dokploy" },
+  { key: "dokku", label: "Dokku" },
+  { key: "coolify", label: "Coolify" },
+];
+
+export const comparisonRows: ComparisonRow[] = [
+  {
+    feature: "Web dashboard",
+    caprover: "Built in",
+    dokploy: "Built in",
+    dokku: "No official dashboard",
+    coolify: "Built in",
+  },
+  {
+    feature: "Dockerfile and prebuilt image deployments",
+    caprover: "Supported",
+    dokploy: "Supported",
+    dokku: "Supported",
+    coolify: "Supported",
+  },
+  {
+    feature: "Git provider support",
+    caprover: "Generic Git plus webhooks",
+    dokploy: "GitHub, GitLab, Gitea and generic Git",
+    dokku: "Git push or sync from any Git remote",
+    coolify: "GitHub, GitLab, Bitbucket, Gitea and generic Git",
+  },
+  {
+    feature: "Docker Compose",
+    caprover: "Partial parser for common fields",
+    dokploy: "First-class support",
+    dokku: "Not an application deployment format",
+    coolify: "First-class support",
+  },
+  {
+    feature: "Application template catalog",
+    caprover: "Open-source One-Click Apps",
+    dokploy: "Open-source templates",
+    dokku: "Plugin ecosystem, no comparable catalog",
+    coolify: "Open-source service templates",
+  },
+  {
+    feature: "Automatic HTTPS",
+    caprover: "Let's Encrypt",
+    dokploy: "Let's Encrypt through Traefik",
+    dokku: "Let's Encrypt integration",
+    coolify: "Let's Encrypt through its proxy",
+  },
+  {
+    feature: "Multi-node orchestration",
+    caprover: "Native Docker Swarm",
+    dokploy: "Native Docker Swarm",
+    dokku: "Optional K3s scheduler",
+    coolify: "Docker Swarm supported",
+  },
+  {
+    feature: "Reverse proxy",
+    caprover: "NGINX",
+    dokploy: "Traefik",
+    dokku: "NGINX by default, alternatives available",
+    coolify: "Traefik by default, Caddy available",
+  },
+  {
+    feature: "Per-app proxy editing in the dashboard",
+    caprover: "Full NGINX template editor",
+    dokploy: "Traefik configuration and domains",
+    dokku: "CLI and template customization",
+    coolify: "Proxy configuration and labels",
+  },
+  {
+    feature: "Platform-managed local registry",
+    caprover: "Built-in provisioning option",
+    dokploy: "Connect an external registry",
+    dokku: "Manual or plugin-based",
+    coolify: "Deployable as a service template",
+  },
+  {
+    feature: "Application rollback",
+    caprover: "One-click source or image rollback",
+    dokploy: "Registry-backed rollback",
+    dokku: "Manual redeploy or retained image",
+    coolify: "Deployment rollback",
+  },
+  {
+    feature: "Low-level container override",
+    caprover: "Docker ServiceUpdate object",
+    dokploy: "Structured Swarm settings",
+    dokku: "Docker options and plugins",
+    coolify: "Custom Docker options or raw Compose",
+  },
+  {
+    feature: "Platform configuration backup",
+    caprover: "Download and restore from dashboard",
+    dokploy: "Scheduled S3 backup and restore",
+    dokku: "Documented manual backup",
+    coolify: "Scheduled and manual instance backup",
+  },
+  {
+    feature: "Resource monitoring",
+    caprover: "Integrated Netdata",
+    dokploy: "Built-in metrics",
+    dokku: "External tooling or plugins",
+    coolify: "Built-in monitoring",
+  },
+];
+
+export const verifiedDate = "August 15, 2026";

--- a/homepage/app/compare/data.ts
+++ b/homepage/app/compare/data.ts
@@ -20,7 +20,7 @@ export const comparisonRows: ComparisonRow[] = [
     feature: "Web dashboard",
     caprover: "Built in",
     dokploy: "Built in",
-    dokku: "No official dashboard",
+    dokku: "No built-in OSS dashboard; Dokku Pro adds one",
     coolify: "Built in",
   },
   {
@@ -33,7 +33,7 @@ export const comparisonRows: ComparisonRow[] = [
   {
     feature: "Git provider support",
     caprover: "Generic Git plus webhooks",
-    dokploy: "GitHub, GitLab, Gitea and generic Git",
+    dokploy: "GitHub, GitLab, Bitbucket, Gitea and generic Git",
     dokku: "Git push or sync from any Git remote",
     coolify: "GitHub, GitLab, Bitbucket, Gitea and generic Git",
   },
@@ -55,7 +55,7 @@ export const comparisonRows: ComparisonRow[] = [
     feature: "Automatic HTTPS",
     caprover: "Let's Encrypt",
     dokploy: "Let's Encrypt through Traefik",
-    dokku: "Let's Encrypt integration",
+    dokku: "Official Let’s Encrypt plugin",
     coolify: "Let's Encrypt through its proxy",
   },
   {
@@ -70,14 +70,14 @@ export const comparisonRows: ComparisonRow[] = [
     caprover: "NGINX",
     dokploy: "Traefik",
     dokku: "NGINX by default, alternatives available",
-    coolify: "Traefik by default, Caddy available",
+    coolify: "Traefik by default; Caddy is experimental",
   },
   {
     feature: "Per-app proxy editing in the dashboard",
     caprover: "Full NGINX template editor",
-    dokploy: "Traefik configuration and domains",
+    dokploy: "Domain UI; Traefik labels or dynamic config",
     dokku: "CLI and template customization",
-    coolify: "Proxy configuration and labels",
+    coolify: "Domain UI; labels or dynamic proxy config",
   },
   {
     feature: "Platform-managed local registry",
@@ -88,10 +88,10 @@ export const comparisonRows: ComparisonRow[] = [
   },
   {
     feature: "Application rollback",
-    caprover: "One-click source or image rollback",
-    dokploy: "Registry-backed rollback",
+    caprover: "Rebuilds and redeploys a selected prior version",
+    dokploy: "Optional registry-backed version rollback",
     dokku: "Manual redeploy or retained image",
-    coolify: "Deployment rollback",
+    coolify: "Rollback to a locally retained application image",
   },
   {
     feature: "Low-level container override",
@@ -102,7 +102,7 @@ export const comparisonRows: ComparisonRow[] = [
   },
   {
     feature: "Platform configuration backup",
-    caprover: "Download and restore from dashboard",
+    caprover: "Dashboard download; restore during installation",
     dokploy: "Scheduled S3 backup and restore",
     dokku: "Documented manual backup",
     coolify: "Scheduled and manual instance backup",

--- a/homepage/app/compare/dokku/page.tsx
+++ b/homepage/app/compare/dokku/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next";
+import {
+  ChoiceGrid,
+  ComparePage,
+  ComparisonPrinciples,
+  MatchupLinks,
+  PageHero,
+  SourceLinks,
+} from "../components";
+
+export const metadata: Metadata = {
+  title: "CapRover vs Dokku: Dashboard or CLI-First PaaS?",
+  description:
+    "Compare CapRover and Dokku across deployment workflow, Docker orchestration, NGINX, buildpacks, plugins, templates and operations.",
+  alternates: { canonical: "https://caprover.com/compare/dokku/" },
+};
+
+const rows = [
+  ["Primary interface", "Web dashboard plus CLI and API", "SSH and CLI"],
+  ["Default scheduler", "Docker Swarm", "Local Docker scheduler"],
+  ["Optional multi-node scheduler", "Additional Docker Swarm nodes", "K3s scheduler"],
+  ["Source deployment", "caprover deploy, archive upload or webhook", "git push, git sync or archive import"],
+  ["Build methods", "Dockerfile, CapRover templates or image", "Dockerfile, Herokuish, Cloud Native Buildpacks or image"],
+  ["Reverse proxy", "NGINX with dashboard editor", "NGINX by default, configurable through CLI and templates"],
+  ["App catalog", "Open-source One-Click Apps", "Plugins and datastore plugins, no comparable app catalog"],
+  ["Scheduled jobs", "Run as an application or external scheduler", "Built-in cron task support"],
+];
+
+export default function DokkuComparison() {
+  return (
+    <ComparePage>
+      <PageHero
+        eyebrow="CAPROVER VS DOKKU"
+        title="A visual Docker control plane or a composable CLI?"
+        intro="CapRover and Dokku both provide a Heroku-like path from source code to a running application. CapRover packages common infrastructure operations into a web dashboard and Docker Swarm. Dokku favors SSH commands, Git push and a deep plugin system."
+      >
+        <div className="verdict"><strong>Short answer</strong><p>Choose CapRover when a dashboard, One-Click Apps and Swarm management should be part of the product. Choose Dokku when you prefer an automation-friendly CLI, buildpacks, cron and a modular plugin architecture.</p></div>
+      </PageHero>
+
+      <section className="compare-section compare-shell">
+        <ComparisonPrinciples />
+        <div className="two-column-table-wrap">
+          <table className="two-column-table">
+            <thead><tr><th>Area</th><th>CapRover</th><th>Dokku</th></tr></thead>
+            <tbody>{rows.map(([area, caprover, dokku]) => <tr key={area}><th>{area}</th><td>{caprover}</td><td>{dokku}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="compare-section compare-soft">
+        <div className="compare-shell article-layout">
+          <article>
+            <h2>Interaction model</h2>
+            <p>CapRover is designed to make application and server operations visible. Domains, certificates, environment variables, persistence, replicas, logs, NGINX configuration and Swarm nodes are available through its dashboard. Its CLI focuses on setup, login and application deployment.</p>
+            <p>Dokku treats the command line as the product interface. Applications are created and configured through SSH commands, making the workflow easy to script and compose with existing Unix tooling. There is no official Dokku web dashboard.</p>
+          </article>
+          <article>
+            <h2>Deployment and builds</h2>
+            <p>CapRover commonly builds a Dockerfile described by captain-definition, deploys a prebuilt image, or receives source through its CLI and webhooks. Its One-Click format can define multiple related services using a Compose-like subset.</p>
+            <p>Dokku's traditional workflow is a Git push to the server. It can build with Dockerfiles, Herokuish or Cloud Native Buildpacks, and it can initialize applications from remote Git repositories, images or archives.</p>
+          </article>
+          <article>
+            <h2>Scaling architecture</h2>
+            <p>CapRover enables Docker Swarm during installation, even for a single machine. Adding workers extends the same scheduling model across servers, and the dashboard can change application replica counts.</p>
+            <p>Dokku uses its local Docker scheduler by default. Its official K3s scheduler adds a Kubernetes-based multi-node path. This is a real cluster option, but it is architecturally different from CapRover's Swarm model.</p>
+          </article>
+          <article>
+            <h2>Extensibility</h2>
+            <p>CapRover exposes advanced behavior through NGINX templates, pre-deploy scripts and a raw Docker ServiceUpdate override. Its One-Click Apps repository focuses on deployable applications and databases.</p>
+            <p>Dokku is itself assembled from plugins and offers a mature plugin-trigger system. Official and community plugins add datastores, schedulers, proxies and other capabilities. Dokku also supports global environment variables and scheduled cron tasks directly.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="compare-section compare-shell">
+        <ChoiceGrid
+          caprover={[
+            "A web dashboard is important for daily operations.",
+            "You want Docker Swarm clustering managed as part of the platform.",
+            "You rely on an open-source catalog of deployable applications and databases.",
+            "You want per-app NGINX editing without building a plugin.",
+          ]}
+          competitorName="Dokku"
+          competitor={[
+            "You prefer SSH commands and Git push as the primary interface.",
+            "Buildpacks and a composable plugin system are important.",
+            "You need built-in cron task definitions or global environment variables.",
+            "You want an optional Kubernetes-based scheduler rather than Docker Swarm.",
+          ]}
+        />
+      </section>
+
+      <section className="compare-section compare-shell">
+        <h2>Migration considerations</h2>
+        <div className="migration-grid">
+          <p><strong>Moving to CapRover:</strong> convert Dokku configuration into CapRover environment variables and app settings, add captain-definition files, map domains, and migrate datastore contents independently.</p>
+          <p><strong>Moving to Dokku:</strong> create applications and domains through the CLI, translate captain-definition into Dockerfiles or buildpack settings, install required datastore plugins, and replace Swarm-specific behavior.</p>
+        </div>
+      </section>
+
+      <section className="compare-section compare-shell">
+        <MatchupLinks current="dokku" />
+        <SourceLinks>
+          <li><a href="https://caprover.com/docs/cli-commands.html">CapRover CLI deployment</a></li>
+          <li><a href="https://caprover.com/docs/one-click-apps.html">CapRover One-Click Apps</a></li>
+          <li><a href="https://caprover.com/docs/nginx-customization.html">CapRover NGINX customization</a></li>
+          <li><a href="https://dokku.com/docs/getting-started/installation/">Dokku architecture and installation</a></li>
+          <li><a href="https://dokku.com/docs/deployment/methods/git/">Dokku Git deployment</a></li>
+          <li><a href="https://dokku.com/docs/deployment/schedulers/k3s/">Dokku K3s scheduler</a></li>
+          <li><a href="https://dokku.com/docs/configuration/environment-variables/">Dokku global and app environment variables</a></li>
+        </SourceLinks>
+      </section>
+    </ComparePage>
+  );
+}

--- a/homepage/app/compare/dokku/page.tsx
+++ b/homepage/app/compare/dokku/page.tsx
@@ -57,12 +57,12 @@ export default function DokkuComparison() {
           <article>
             <h2>Deployment and builds</h2>
             <p>CapRover commonly builds a Dockerfile described by captain-definition, deploys a prebuilt image, or receives source through its CLI and webhooks. Its One-Click format can define multiple related services using a Compose-like subset.</p>
-            <p>Dokku's traditional workflow is a Git push to the server. It can build with Dockerfiles, Herokuish or Cloud Native Buildpacks, and it can initialize applications from remote Git repositories, images or archives.</p>
+            <p>Dokku’s traditional workflow is a Git push to the server. It can build with Dockerfiles, Herokuish or Cloud Native Buildpacks, and it can initialize applications from remote Git repositories, images or archives.</p>
           </article>
           <article>
             <h2>Scaling architecture</h2>
             <p>CapRover enables Docker Swarm during installation, even for a single machine. Adding workers extends the same scheduling model across servers, and the dashboard can change application replica counts.</p>
-            <p>Dokku uses its local Docker scheduler by default. Its official K3s scheduler adds a Kubernetes-based multi-node path. This is a real cluster option, but it is architecturally different from CapRover's Swarm model.</p>
+            <p>Dokku uses its local Docker scheduler by default. Its official K3s scheduler adds a Kubernetes-based multi-node path. This is a real cluster option, but it is architecturally different from CapRover’s Swarm model.</p>
           </article>
           <article>
             <h2>Extensibility</h2>

--- a/homepage/app/compare/dokku/page.tsx
+++ b/homepage/app/compare/dokku/page.tsx
@@ -16,11 +16,11 @@ export const metadata: Metadata = {
 };
 
 const rows = [
-  ["Primary interface", "Web dashboard plus CLI and API", "SSH and CLI"],
+  ["Primary interface", "Web dashboard plus CLI and API", "SSH and CLI in OSS core; Dokku Pro adds a web UI and API"],
   ["Default scheduler", "Docker Swarm", "Local Docker scheduler"],
   ["Optional multi-node scheduler", "Additional Docker Swarm nodes", "K3s scheduler"],
   ["Source deployment", "caprover deploy, archive upload or webhook", "git push, git sync or archive import"],
-  ["Build methods", "Dockerfile, CapRover templates or image", "Dockerfile, Herokuish, Cloud Native Buildpacks or image"],
+  ["Build methods", "Dockerfile, CapRover templates or image", "Dockerfile, Herokuish, Cloud Native Buildpacks, Nixpacks, Railpack or image"],
   ["Reverse proxy", "NGINX with dashboard editor", "NGINX by default, configurable through CLI and templates"],
   ["App catalog", "Open-source One-Click Apps", "Plugins and datastore plugins, no comparable app catalog"],
   ["Scheduled jobs", "Run as an application or external scheduler", "Built-in cron task support"],
@@ -52,12 +52,12 @@ export default function DokkuComparison() {
           <article>
             <h2>Interaction model</h2>
             <p>CapRover is designed to make application and server operations visible. Domains, certificates, environment variables, persistence, replicas, logs, NGINX configuration and Swarm nodes are available through its dashboard. Its CLI focuses on setup, login and application deployment.</p>
-            <p>Dokku treats the command line as the product interface. Applications are created and configured through SSH commands, making the workflow easy to script and compose with existing Unix tooling. There is no official Dokku web dashboard.</p>
+            <p>Open-source Dokku core treats the command line as its product interface. Applications are created and configured through SSH commands, making the workflow easy to script and compose with existing Unix tooling. The separately licensed Dokku Pro product adds an official web UI and REST API.</p>
           </article>
           <article>
             <h2>Deployment and builds</h2>
             <p>CapRover commonly builds a Dockerfile described by captain-definition, deploys a prebuilt image, or receives source through its CLI and webhooks. Its One-Click format can define multiple related services using a Compose-like subset.</p>
-            <p>Dokku’s traditional workflow is a Git push to the server. It can build with Dockerfiles, Herokuish or Cloud Native Buildpacks, and it can initialize applications from remote Git repositories, images or archives.</p>
+            <p>Dokku’s traditional workflow is a Git push to the server. It can build with Dockerfiles, Herokuish, Cloud Native Buildpacks, Nixpacks or Railpack, and it can initialize applications from remote Git repositories, images or archives.</p>
           </article>
           <article>
             <h2>Scaling architecture</h2>
@@ -108,6 +108,7 @@ export default function DokkuComparison() {
           <li><a href="https://dokku.com/docs/deployment/methods/git/">Dokku Git deployment</a></li>
           <li><a href="https://dokku.com/docs/deployment/schedulers/k3s/">Dokku K3s scheduler</a></li>
           <li><a href="https://dokku.com/docs/configuration/environment-variables/">Dokku global and app environment variables</a></li>
+          <li><a href="https://pro.dokku.com/docs/getting-started/">Dokku Pro web UI and API</a></li>
         </SourceLinks>
       </section>
     </ComparePage>

--- a/homepage/app/compare/dokploy/page.tsx
+++ b/homepage/app/compare/dokploy/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next";
+import {
+  ChoiceGrid,
+  ComparePage,
+  ComparisonPrinciples,
+  MatchupLinks,
+  PageHero,
+  SourceLinks,
+} from "../components";
+
+export const metadata: Metadata = {
+  title: "CapRover vs Dokploy: Technical Comparison",
+  description:
+    "Compare CapRover and Dokploy across Docker Swarm, NGINX, Traefik, Compose, Git deployments, registries, backups and team workflows.",
+  alternates: { canonical: "https://caprover.com/compare/dokploy/" },
+};
+
+const rows = [
+  ["Container orchestration", "Docker Swarm", "Docker Swarm"],
+  ["Default proxy", "NGINX", "Traefik"],
+  ["Docker Compose", "Partial parser for common fields", "First-class Compose and Docker Stack"],
+  ["Application builds", "Dockerfile, templates or prebuilt image", "Dockerfile, Nixpacks, buildpacks or prebuilt image"],
+  ["Remote servers", "Additional nodes join the CapRover Swarm", "Swarm nodes plus independent remote deploy servers"],
+  ["Rollback", "Rebuild or redeploy a previous application version", "Registry-backed deployment images"],
+  ["User model", "Single administrator", "Organizations, users and roles"],
+  ["Low-level control", "Raw Docker ServiceUpdate override", "Structured Swarm configuration and Compose"],
+];
+
+export default function DokployComparison() {
+  return (
+    <ComparePage>
+      <PageHero
+        eyebrow="CAPROVER VS DOKPLOY"
+        title="Two Swarm-oriented platforms with different priorities."
+        intro="CapRover and Dokploy both use Docker Swarm and provide web dashboards, HTTPS automation, application replicas and open-source templates. The largest differences are proxy choice, Compose support, build workflows and how much platform surface area each product exposes."
+      >
+        <div className="verdict"><strong>Short answer</strong><p>Choose CapRover for a focused application model, NGINX control, local CLI deployment and direct Docker service overrides. Choose Dokploy for full Compose, more build strategies, remote deployment servers and multi-user workflows.</p></div>
+      </PageHero>
+
+      <section className="compare-section compare-shell">
+        <ComparisonPrinciples />
+        <div className="two-column-table-wrap">
+          <table className="two-column-table">
+            <thead><tr><th>Area</th><th>CapRover</th><th>Dokploy</th></tr></thead>
+            <tbody>{rows.map(([area, caprover, dokploy]) => <tr key={area}><th>{area}</th><td>{caprover}</td><td>{dokploy}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="compare-section compare-soft">
+        <div className="compare-shell article-layout">
+          <article>
+            <h2>Shared foundation</h2>
+            <p>Both products run their own services in Docker and can schedule application replicas across a Swarm. Both expect a registry when nodes need to pull a built image. Both can automate domains, certificates, health checks, rolling updates and application rollback.</p>
+            <p>This shared foundation makes the comparison more about product boundaries than basic container capability.</p>
+          </article>
+          <article>
+            <h2>NGINX versus Traefik</h2>
+            <p>CapRover generates NGINX configuration and exposes the per-app template in its dashboard. Operators can also override the global server-block template and mount supporting files into the NGINX container.</p>
+            <p>Dokploy uses Traefik and manages domains through generated dynamic configuration or Compose labels. This is a better fit for operators already standardized on Traefik, while CapRover is a better fit when explicit NGINX directives are required.</p>
+          </article>
+          <article>
+            <h2>Application and Compose models</h2>
+            <p>CapRover's primary abstraction is an application backed by a Docker service. It can import a useful subset of Compose through the One-Click parser, but unsupported Compose fields are ignored. Complex definitions should be reviewed rather than assumed compatible.</p>
+            <p>Dokploy treats Compose as a first-class resource and can deploy it through Docker Compose or Docker Stack. It also offers more source-build options, including Nixpacks and buildpacks, and can separate build servers from deployment servers.</p>
+          </article>
+          <article>
+            <h2>Operations and teams</h2>
+            <p>CapRover intentionally uses one administrative security boundary. Dokploy provides organizations, users and roles, with additional governance features in its enterprise offering. Dokploy also provides scheduled S3 platform backups, database backups and named-volume backups.</p>
+            <p>CapRover provides downloadable platform configuration backups, integrated Netdata monitoring and a managed local registry option. Persistent data still needs an application-aware or volume-level backup plan.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="compare-section compare-shell">
+        <ChoiceGrid
+          caprover={[
+            "You want NGINX and dashboard-level access to its generated configuration.",
+            "You prefer a smaller app-centric control plane with fewer resource types.",
+            "You deploy from a local CLI and want direct Docker ServiceUpdate overrides.",
+            "A CapRover-managed registry is useful for your Swarm.",
+          ]}
+          competitorName="Dokploy"
+          competitor={[
+            "Docker Compose and Docker Stack are central deployment formats.",
+            "You need organizations, multiple users or role-based access.",
+            "You want independent remote deployment servers or dedicated build servers.",
+            "Built-in scheduled database and named-volume backups are priorities.",
+          ]}
+        />
+      </section>
+
+      <section className="compare-section compare-shell">
+        <h2>Migration considerations</h2>
+        <div className="migration-grid">
+          <p><strong>Moving to CapRover:</strong> split complex Compose stacks into CapRover apps or validate them against the supported One-Click fields. Recreate routing in NGINX and transfer persistent data separately.</p>
+          <p><strong>Moving to Dokploy:</strong> express each CapRover app as an application or Compose service, replace NGINX-specific directives with Traefik configuration, and configure a registry for clustered rollbacks.</p>
+        </div>
+      </section>
+
+      <section className="compare-section compare-shell">
+        <MatchupLinks current="dokploy" />
+        <SourceLinks>
+          <li><a href="https://caprover.com/docs/service-update-override.html">CapRover Docker service overrides</a></li>
+          <li><a href="https://caprover.com/docs/docker-compose.html">CapRover Compose compatibility</a></li>
+          <li><a href="https://caprover.com/docs/app-scaling-and-cluster.html">CapRover Swarm clustering and registry</a></li>
+          <li><a href="https://docs.dokploy.com/docs/core/docker-compose">Dokploy Docker Compose</a></li>
+          <li><a href="https://docs.dokploy.com/docs/core/cluster">Dokploy clusters</a></li>
+          <li><a href="https://docs.dokploy.com/docs/core/backups">Dokploy platform backups</a></li>
+          <li><a href="https://docs.dokploy.com/docs/core/volume-backups">Dokploy named-volume backups</a></li>
+        </SourceLinks>
+      </section>
+    </ComparePage>
+  );
+}

--- a/homepage/app/compare/dokploy/page.tsx
+++ b/homepage/app/compare/dokploy/page.tsx
@@ -61,7 +61,7 @@ export default function DokployComparison() {
           </article>
           <article>
             <h2>Application and Compose models</h2>
-            <p>CapRover's primary abstraction is an application backed by a Docker service. It can import a useful subset of Compose through the One-Click parser, but unsupported Compose fields are ignored. Complex definitions should be reviewed rather than assumed compatible.</p>
+            <p>CapRover’s primary abstraction is an application backed by a Docker service. It can import a useful subset of Compose through the One-Click parser, but unsupported Compose fields are ignored. Complex definitions should be reviewed rather than assumed compatible.</p>
             <p>Dokploy treats Compose as a first-class resource and can deploy it through Docker Compose or Docker Stack. It also offers more source-build options, including Nixpacks and buildpacks, and can separate build servers from deployment servers.</p>
           </article>
           <article>

--- a/homepage/app/compare/layout.tsx
+++ b/homepage/app/compare/layout.tsx
@@ -1,0 +1,7 @@
+import "./comparison.css";
+
+export default function CompareLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/homepage/app/compare/page.tsx
+++ b/homepage/app/compare/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import {
+  ComparePage,
+  ComparisonPrinciples,
+  ComparisonTable,
+  MatchupLinks,
+  PageHero,
+  SourceLinks,
+} from "./components";
+
+export const metadata: Metadata = {
+  title: "Compare CapRover, Coolify, Dokploy and Dokku",
+  description:
+    "A sourced technical comparison of CapRover, Coolify, Dokploy and Dokku across deployment, networking, clustering, rollback and operations.",
+  alternates: { canonical: "https://caprover.com/compare/" },
+};
+
+export default function ComparisonHub() {
+  return (
+    <ComparePage>
+      <PageHero
+        eyebrow="SELF-HOSTED PAAS COMPARISON"
+        title="Choose the deployment model that fits your infrastructure."
+        intro="CapRover, Coolify, Dokploy and Dokku can all deploy containerized applications, but they make different architectural and operational tradeoffs. This comparison uses specific capability descriptions instead of unexplained checkmarks."
+      />
+      <section className="compare-section compare-shell">
+        <ComparisonPrinciples />
+        <ComparisonTable focus="caprover" />
+      </section>
+
+      <section className="compare-section compare-soft">
+        <div className="compare-shell prose-grid">
+          <div>
+            <p className="compare-kicker">CAPROVER'S DESIGN CENTER</p>
+            <h2>Simple application management with Docker controls underneath.</h2>
+          </div>
+          <div className="prose-copy">
+            <p>
+              CapRover is centered on a straightforward application model: deploy source or an
+              image, attach domains, configure persistence, and let Docker Swarm and NGINX handle
+              the runtime. The dashboard covers common operations while NGINX templates and Docker
+              service overrides remain available when the defaults are not enough.
+            </p>
+            <p>
+              That focus means CapRover does not attempt to provide every workflow found in newer
+              platforms. Teams that require first-class Compose, preview environments or granular
+              roles should evaluate those needs directly rather than treating every feature as
+              equally important.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="compare-section compare-shell">
+        <div className="compare-heading">
+          <p className="compare-kicker">ONE-ON-ONE COMPARISONS</p>
+          <h2>Go deeper on the products you are considering.</h2>
+          <p>Each page discusses architecture, strengths, limitations and migration considerations specific to that matchup.</p>
+        </div>
+        <MatchupLinks />
+      </section>
+
+      <section className="compare-section compare-shell">
+        <SourceLinks>
+          <li><a href="https://caprover.com/docs/deployment-methods.html">CapRover deployment methods and rollback</a></li>
+          <li><a href="https://caprover.com/docs/docker-compose.html">CapRover Docker Compose compatibility</a></li>
+          <li><a href="https://caprover.com/docs/app-scaling-and-cluster.html">CapRover Docker Swarm clustering</a></li>
+          <li><a href="https://caprover.com/docs/nginx-customization.html">CapRover NGINX customization</a></li>
+          <li><a href="https://docs.dokploy.com/docs/core">Dokploy documentation</a></li>
+          <li><a href="https://dokku.com/docs/">Dokku documentation</a></li>
+          <li><a href="https://coolify.io/docs">Coolify documentation</a></li>
+        </SourceLinks>
+      </section>
+    </ComparePage>
+  );
+}

--- a/homepage/app/compare/page.tsx
+++ b/homepage/app/compare/page.tsx
@@ -65,9 +65,11 @@ export default function ComparisonHub() {
           <li><a href="https://caprover.com/docs/deployment-methods.html">CapRover deployment methods and rollback</a></li>
           <li><a href="https://caprover.com/docs/docker-compose.html">CapRover Docker Compose compatibility</a></li>
           <li><a href="https://caprover.com/docs/app-scaling-and-cluster.html">CapRover Docker Swarm clustering</a></li>
+          <li><a href="https://caprover.com/docs/backup-and-restore.html">CapRover backup and restoration scope</a></li>
           <li><a href="https://caprover.com/docs/nginx-customization.html">CapRover NGINX customization</a></li>
           <li><a href="https://docs.dokploy.com/docs/core">Dokploy documentation</a></li>
           <li><a href="https://dokku.com/docs/">Dokku documentation</a></li>
+          <li><a href="https://pro.dokku.com/docs/getting-started/">Dokku Pro web UI and API</a></li>
           <li><a href="https://coolify.io/docs">Coolify documentation</a></li>
         </SourceLinks>
       </section>

--- a/homepage/app/compare/page.tsx
+++ b/homepage/app/compare/page.tsx
@@ -31,7 +31,7 @@ export default function ComparisonHub() {
       <section className="compare-section compare-soft">
         <div className="compare-shell prose-grid">
           <div>
-            <p className="compare-kicker">CAPROVER'S DESIGN CENTER</p>
+            <p className="compare-kicker">CAPROVER’S DESIGN CENTER</p>
             <h2>Simple application management with Docker controls underneath.</h2>
           </div>
           <div className="prose-copy">

--- a/homepage/app/sitemap.ts
+++ b/homepage/app/sitemap.ts
@@ -1,5 +1,7 @@
 import type { MetadataRoute } from "next";
 
+export const dynamic = "force-static";
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://caprover.com";
   const lastModified = new Date("2026-08-15");

--- a/homepage/app/sitemap.ts
+++ b/homepage/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://caprover.com";
+  const lastModified = new Date("2026-08-15");
+
+  return [
+    { url: base, lastModified, changeFrequency: "monthly", priority: 1 },
+    { url: `${base}/compare/`, lastModified, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/compare/coolify/`, lastModified, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/compare/dokploy/`, lastModified, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/compare/dokku/`, lastModified, changeFrequency: "monthly", priority: 0.6 },
+  ];
+}

--- a/homepage/next.config.ts
+++ b/homepage/next.config.ts
@@ -4,6 +4,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 
 const nextConfig: NextConfig = {
   output: "export",
+  trailingSlash: true,
   basePath,
 };
 

--- a/homepage/tests/static-export.test.mjs
+++ b/homepage/tests/static-export.test.mjs
@@ -34,3 +34,20 @@ test("exports a complete static homepage", async () => {
     assert.match(html, new RegExp(`href=["']${basePath}/_next/`));
   }
 });
+
+
+test("exports the comparison hub and one-on-one pages without changing homepage navigation", async () => {
+  const homepage = await readFile("out/index.html", "utf8");
+  const hub = await readFile("out/compare/index.html", "utf8");
+  const coolify = await readFile("out/compare/coolify/index.html", "utf8");
+  const dokploy = await readFile("out/compare/dokploy/index.html", "utf8");
+  const dokku = await readFile("out/compare/dokku/index.html", "utf8");
+  const sitemap = await readFile("out/sitemap.xml", "utf8");
+
+  assert.doesNotMatch(homepage, /href=["'][^"']*\/compare\/?["']/);
+  assert.match(hub, /Choose the deployment model/);
+  assert.match(coolify, /CAPROVER VS COOLIFY/);
+  assert.match(dokploy, /CAPROVER VS DOKPLOY/);
+  assert.match(dokku, /CAPROVER VS DOKKU/);
+  assert.match(sitemap, /https:\/\/caprover\.com\/compare\/coolify\//);
+});

--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -66,8 +66,15 @@ await Promise.all([
   requirePath(path.join(homepage, "index.html")),
   requirePath(path.join(homepage, "_next")),
   requirePath(path.join(homepage, "homepage-assets")),
+  requirePath(path.join(homepage, "compare/index.html")),
+  requirePath(path.join(homepage, "compare/coolify/index.html")),
+  requirePath(path.join(homepage, "compare/dokploy/index.html")),
+  requirePath(path.join(homepage, "compare/dokku/index.html")),
+  requirePath(path.join(homepage, "sitemap.xml")),
   requireNoCollision("_next"),
   requireNoCollision("homepage-assets"),
+  requireNoCollision("compare"),
+  requireNoCollision("sitemap.xml"),
 ]);
 
 const originalCname = await readFile(path.join(legacySite, "CNAME"));
@@ -91,6 +98,10 @@ await cp(
   path.join(combinedSite, "homepage-assets"),
   { recursive: true },
 );
+await cp(path.join(homepage, "compare"), path.join(combinedSite, "compare"), {
+  recursive: true,
+});
+await cp(path.join(homepage, "sitemap.xml"), path.join(combinedSite, "sitemap.xml"));
 await writeFile(path.join(combinedSite, ".nojekyll"), "");
 await requirePath(path.join(combinedSite, ".nojekyll"));
 

--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -74,7 +74,6 @@ await Promise.all([
   requireNoCollision("_next"),
   requireNoCollision("homepage-assets"),
   requireNoCollision("compare"),
-  requireNoCollision("sitemap.xml"),
 ]);
 
 const originalCname = await readFile(path.join(legacySite, "CNAME"));
@@ -101,7 +100,19 @@ await cp(
 await cp(path.join(homepage, "compare"), path.join(combinedSite, "compare"), {
   recursive: true,
 });
-await cp(path.join(homepage, "sitemap.xml"), path.join(combinedSite, "sitemap.xml"));
+const [legacySitemap, homepageSitemap] = await Promise.all([
+  readFile(path.join(combinedSite, "sitemap.xml"), "utf8"),
+  readFile(path.join(homepage, "sitemap.xml"), "utf8"),
+]);
+const comparisonUrls = (homepageSitemap.match(/<url>[\s\S]*?<\/url>/g) ?? []).filter(
+  (entry) => entry.includes("/compare/"),
+);
+assert(comparisonUrls.length === 4, "Homepage sitemap is missing comparison URLs");
+assert.match(legacySitemap, /<\/urlset>\s*$/);
+await writeFile(
+  path.join(combinedSite, "sitemap.xml"),
+  legacySitemap.replace(/<\/urlset>\s*$/, `${comparisonUrls.join("\\n")}\n</urlset>\n`),
+);
 await writeFile(path.join(combinedSite, ".nojekyll"), "");
 await requirePath(path.join(combinedSite, ".nojekyll"));
 

--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -111,7 +111,7 @@ assert(comparisonUrls.length === 4, "Homepage sitemap is missing comparison URLs
 assert.match(legacySitemap, /<\/urlset>\s*$/);
 await writeFile(
   path.join(combinedSite, "sitemap.xml"),
-  legacySitemap.replace(/<\/urlset>\s*$/, `${comparisonUrls.join("\\n")}\n</urlset>\n`),
+  legacySitemap.replace(/<\/urlset>\s*$/, `${comparisonUrls.join("\n")}\n</urlset>\n`),
 );
 await writeFile(path.join(combinedSite, ".nojekyll"), "");
 await requirePath(path.join(combinedSite, ".nojekyll"));


### PR DESCRIPTION
## What changed

- Adds a comparison hub at `/compare/`
- Adds focused pages for CapRover vs Coolify, Dokploy, and Dokku
- Uses narrow, text-based capability descriptions instead of ambiguous checkmarks
- Adds official-source links, methodology notes, canonical metadata, and sitemap discovery
- Merges comparison URLs into the existing documentation sitemap
- Updates the combined-site composition script and static export regression coverage
- Intentionally does not add links from the homepage, header, or footer

## Content methodology

Claims are scoped to specific capabilities and distinguish built-in, partial, plugin-based, manual, experimental, and prerequisite-dependent support. Unless a row says otherwise, the scope is the current self-hosted open-source edition. Paid or enterprise additions, such as Dokku Pro, are named explicitly.

The pages emphasize architecture, operational tradeoffs, and fit rather than presenting every difference as a winner or loser. Each comparison links to official documentation and includes a verification date.

## Claims audit

A second official-documentation audit corrected or qualified:

- Dokku core has no built-in OSS dashboard, but the official Dokku Pro product adds a web UI and API
- CapRover backup creation is available in the dashboard, while restore occurs during installation
- CapRover backups exclude images by default, but include images stored in its self-hosted registry
- Coolify Caddy support is experimental
- Coolify rollback requires a locally retained application image
- Dokploy registry-backed version rollback is optional and requires registry configuration
- Dokku's current Nixpacks and Railpack builders are included

## Validation

- GitHub Actions `Verify homepage integration` passes after the claims audit
- Lint and TypeScript checks pass
- Static export tests confirm all four comparison routes
- Regression assertion rejects a `/compare` link in the homepage export
- Combined-site composition, sitemap merge, smoke tests, and preview artifact upload pass
- Connector diff inspected with no homepage component edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comparison hub covering CapRover, Coolify, Dokploy, and Dokku.
  * Added dedicated comparison pages with feature tables, deployment guidance, migration considerations, recommendations, and source links.
  * Added responsive layouts, accessible navigation, SEO metadata, and sitemap entries for comparison content.
* **Bug Fixes**
  * Improved static site generation and validation for comparison pages and sitemap integration.
  * Standardized trailing-slash URLs across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->