### PR TITLE
Activate Spanish documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Translations are committed directly to the repository:
 - Add a locale to `website/languages.js` only after its documents and UI strings
   are complete.
 
-`website/translated_docs/es-ES/` contains the Spanish documentation. Spanish
-remains disabled in `website/languages.js` until its Docusaurus UI strings are
-complete.
+Spanish is enabled in `website/languages.js`. Its documentation is published at
+`/docs/es-ES/*.html`, and the Docusaurus language menu switches between English
+and Spanish versions of the current document.
 
 ## Translation guidelines
 

--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -62,6 +62,7 @@ async function snapshot(directory) {
 await Promise.all([
   requirePath(path.join(legacySite, "docs/get-started.html")),
   requirePath(path.join(legacySite, "docs/en/get-started.html")),
+  requirePath(path.join(legacySite, "docs/es-ES/get-started.html")),
   requirePath(path.join(legacySite, "img/logo.png")),
   requirePath(path.join(legacySite, "CNAME")),
   requirePath(path.join(homepage, "index.html")),
@@ -76,7 +77,6 @@ await Promise.all([
   requireNoCollision("_next"),
   requireNoCollision("homepage-assets"),
   requireNoCollision("compare"),
-  requireNoCollision("en"),
 ]);
 
 const originalCname = await readFile(path.join(legacySite, "CNAME"));
@@ -103,6 +103,7 @@ await cp(
 await cp(path.join(homepage, "compare"), path.join(combinedSite, "compare"), {
   recursive: true,
 });
+await rm(path.join(combinedSite, "en"), { recursive: true, force: true });
 await cp(path.join(homepage, "en"), path.join(combinedSite, "en"), {
   recursive: true,
 });

--- a/scripts/smoke-combined-site.mjs
+++ b/scripts/smoke-combined-site.mjs
@@ -54,6 +54,7 @@ try {
     fetch(`${origin}/.nojekyll`),
     fetch(`${origin}/docs/get-started.html`),
     fetch(`${origin}/docs/en/get-started.html`),
+    fetch(`${origin}/docs/es-ES/get-started.html`),
     fetch(`${origin}/en/index.html`),
     fetch(`${origin}/homepage-assets/caprover-dashboard.png`),
     fetch(`${origin}${nextAsset}`),
@@ -69,10 +70,16 @@ try {
 
   const docs = await checks[2].text();
   assert.match(docs, /Getting Started/i);
-  const englishHomepageAlias = await checks[3].text();
+  assert.match(docs, /href=["']\/docs\/es-ES\/get-started\.html["']/);
+  const spanishDocs = await checks[3].text();
+  assert.match(spanishDocs, /<html lang=["']es-ES["']/);
+  assert.match(spanishDocs, /Primeros pasos/);
+  assert.match(spanishDocs, /Conceptos básicos/);
+  assert.match(spanishDocs, /href=["']\/docs\/en\/get-started\.html["']/);
+  const englishHomepageAlias = await checks[4].text();
   assert.match(englishHomepageAlias, /Deploy apps\./);
   assert.match(englishHomepageAlias, /rel=["']canonical["'][^>]+href=["']https:\/\/caprover\.com\/["']/);
-  assert(Number(checks[4].headers.get("content-length") ?? 0) > 0 || (await checks[4].arrayBuffer()).byteLength > 0);
+  assert(Number(checks[5].headers.get("content-length") ?? 0) > 0 || (await checks[5].arrayBuffer()).byteLength > 0);
 
   const docsStylesheet = docs.match(
     /href=["\'](\/css\/main\.css(?:\?[^"\']*)?)["\']/,

--- a/website/i18n/es-ES.json
+++ b/website/i18n/es-ES.json
@@ -1,0 +1,170 @@
+{
+  "_comment": "Traducciones al español para Docusaurus.",
+  "localized-strings": {
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "tagline": "PaaS escalable, gratuita y autoalojada.",
+    "docs": {
+      "app-configuration": {
+        "title": "Configuración de la aplicación",
+        "sidebar_label": "Configuración de la aplicación"
+      },
+      "app-scaling-and-cluster": {
+        "title": "Escalado de aplicaciones y clúster",
+        "sidebar_label": "Escalado de aplicaciones y clúster"
+      },
+      "backup-and-restore": {
+        "title": "Copia de seguridad y restauración",
+        "sidebar_label": "Copia de seguridad y restauración"
+      },
+      "best-practices": {
+        "title": "Mejores prácticas",
+        "sidebar_label": "Mejores prácticas"
+      },
+      "captain-definition-file": {
+        "title": "Archivo de definición de Captain",
+        "sidebar_label": "Archivo de definición de Captain"
+      },
+      "cdd-migration": {
+        "title": "Migración desde CaptainDuckDuck",
+        "sidebar_label": "Migración desde CaptainDuckDuck"
+      },
+      "certbot-config": {
+        "title": "Overrides de Certbot",
+        "sidebar_label": "Overrides de Certbot"
+      },
+      "ci-cd-integration": {
+        "title": "Integración CI/CD",
+        "sidebar_label": "Introducción"
+      },
+      "ci-cd-integration/deploy-from-github": {
+        "title": "Construya, pruebe e implemente desde GitHub",
+        "sidebar_label": "Implementar desde GitHub"
+      },
+      "ci-cd-integration/deploy-from-gitlab": {
+        "title": "Desplegar desde GitLab",
+        "sidebar_label": "Implementar desde GitLab"
+      },
+      "cli-commands": {
+        "title": "Comandos CLI",
+        "sidebar_label": "Comandos CLI"
+      },
+      "complete-webapp-tutorial": {
+        "title": "Tutorial completo de aplicaciones web",
+        "sidebar_label": "Tutorial completo de aplicaciones web"
+      },
+      "database-connection": {
+        "title": "Conexión de base de datos",
+        "sidebar_label": "Conexión de base de datos"
+      },
+      "deployment-methods": {
+        "title": "Métodos de implementación",
+        "sidebar_label": "Métodos de implementación"
+      },
+      "disk-cleanup": {
+        "title": "Limpieza de disco",
+        "sidebar_label": "Limpieza de disco"
+      },
+      "docker-compose": {
+        "title": "Docker Compose",
+        "sidebar_label": "Docker Compose"
+      },
+      "firewall": {
+        "title": "Cortafuegos y reenvío de puertos",
+        "sidebar_label": "Cortafuegos y reenvío de puertos"
+      },
+      "get-started": {
+        "title": "Primeros pasos",
+        "sidebar_label": "Primeros pasos"
+      },
+      "nginx-customization": {
+        "title": "Configuración de NGINX",
+        "sidebar_label": "Configuración de NGINX"
+      },
+      "one-click-apps": {
+        "title": "One-Click Apps",
+        "sidebar_label": "One-Click Apps"
+      },
+      "persistent-apps": {
+        "title": "Aplicaciones persistentes",
+        "sidebar_label": "Aplicaciones persistentes"
+      },
+      "play-with-docker": {
+        "title": "Juega con CapRover",
+        "sidebar_label": "Juega con CapRover"
+      },
+      "pre-deploy-script": {
+        "title": "Script previo a la implementación",
+        "sidebar_label": "Script previo a la implementación"
+      },
+      "recipe-deploy-create-react-app": {
+        "title": "Aplicación estática React",
+        "sidebar_label": "Aplicación estática React"
+      },
+      "resource-monitoring": {
+        "title": "Monitoreo de recursos",
+        "sidebar_label": "Monitoreo de recursos"
+      },
+      "run-locally": {
+        "title": "Ejecutar localmente",
+        "sidebar_label": "Ejecutar localmente"
+      },
+      "sample-apps": {
+        "title": "Aplicaciones de muestra",
+        "sidebar_label": "Aplicaciones de muestra"
+      },
+      "server-purchase/digitalocean": {
+        "title": "Configurando CapRover con DigitalOcean",
+        "sidebar_label": "DigitalOcean"
+      },
+      "server-purchase/openstack": {
+        "title": "Configurando CapRover con OpenStack",
+        "sidebar_label": "OpenStack"
+      },
+      "service-update-override": {
+        "title": "Anulación de actualización de servicio",
+        "sidebar_label": "Anulación de actualización de servicio"
+      },
+      "stateless-with-persistent-data": {
+        "title": "Sin estado con datos persistentes",
+        "sidebar_label": "Sin estado con datos persistentes"
+      },
+      "support": {
+        "title": "Ayuda y soporte",
+        "sidebar_label": "Ayuda y soporte"
+      },
+      "theme-customization": {
+        "title": "Temas personalizados",
+        "sidebar_label": "Temas personalizados"
+      },
+      "troubleshooting-pro": {
+        "title": "Solución de problemas de CapRover Pro",
+        "sidebar_label": "Solución de problemas (Pro)"
+      },
+      "troubleshooting": {
+        "title": "Solución de problemas",
+        "sidebar_label": "Solución de problemas"
+      },
+      "zero-downtime": {
+        "title": "Implementaciones sin tiempo de inactividad",
+        "sidebar_label": "Tiempo de inactividad cero"
+      }
+    },
+    "links": {
+      "Docs": "Documentación",
+      "GitHub": "GitHub",
+      "Slack Group": "Grupo de Slack"
+    },
+    "categories": {
+      "Basics": "Conceptos básicos",
+      "Do More": "Más opciones",
+      "Recipes and Tips": "Recetas y consejos",
+      "Help": "Ayuda"
+    }
+  },
+  "pages-strings": {
+    "Help Translate|recruit community translators for your project": "Ayuda a traducir",
+    "Edit this Doc|recruitment message asking to edit the doc source": "Editar",
+    "Translate this Doc|recruitment message asking to translate the docs": "Traducir"
+  }
+}

--- a/website/languages.js
+++ b/website/languages.js
@@ -1,1 +1,12 @@
-module.exports = ["en"];
+module.exports = [
+  {
+    enabled: true,
+    name: "English",
+    tag: "en",
+  },
+  {
+    enabled: true,
+    name: "Español",
+    tag: "es-ES",
+  },
+];

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -28,6 +28,7 @@ const siteConfig = {
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
     { doc: "get-started", label: "Docs" },
+    { languages: true },
     {
       href: "https://github.com/caprover/caprover",
       label: "GitHub",


### PR DESCRIPTION
## Summary

- enable English and Spanish in the Docusaurus language configuration
- add Spanish navigation, sidebar, document-title, and interface strings
- add the documentation language selector
- publish all translated documents under `/docs/es-ES/`
- preserve the Next.js English homepage alias during combined-site composition
- verify English and Spanish documentation routes in the combined-site smoke test

## Validation

- `cd website && npm run clean-build`
- `cd homepage && npm run lint`
- `cd homepage && npm test`
- validated 85 Spanish UI strings and 36 Spanish documents
- `node scripts/compose-site.mjs`
- `node scripts/smoke-combined-site.mjs`
- `git diff --check`