### PR TITLE
Add robots.txt with sitemap discovery

### DIFF
--- a/docs-site/static/robots.txt
+++ b/docs-site/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://caprover.com/sitemap.xml

--- a/scripts/smoke-combined-site.mjs
+++ b/scripts/smoke-combined-site.mjs
@@ -120,6 +120,7 @@ try {
     fetch(`${origin}/es-ES/compare/dokku/index.html`),
     fetch(`${origin}/homepage-assets/caprover-dashboard.png`),
     fetch(`${origin}${nextAsset}`),
+    fetch(`${origin}/robots.txt`),
   ]);
 
   for (const response of checks) {
@@ -156,6 +157,10 @@ try {
     assert.match(page, /\/es-ES\/docs\/get-started/);
   }
   assert(Number(checks[12].headers.get("content-length") ?? 0) > 0 || (await checks[12].arrayBuffer()).byteLength > 0);
+  assert.equal(
+    await checks[14].text(),
+    "User-agent: *\nAllow: /\nSitemap: https://caprover.com/sitemap.xml\n",
+  );
 
   function docsStylesheet(html) {
     const match = html.match(


### PR DESCRIPTION
## Summary

- allow public crawlers
- advertise the canonical sitemap
- verify `robots.txt` in the combined-site smoke test

## Validation

- bilingual Docusaurus production build
- combined-site composition
- combined-site HTTP smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `robots.txt` file that permits search engine crawling and identifies the site sitemap.

- **Tests**
  - Added automated coverage to verify the file is available and contains the expected crawler and sitemap directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->