### PR TITLE
Clean up legacy Docusaurus deployment scaffolding

### DIFF
--- a/docs-site/build_dir
+++ b/docs-site/build_dir
@@ -1,1 +1,0 @@
-export BUILD_DIR="./build/CapRover"

--- a/docs-site/publish-from-actions.sh
+++ b/docs-site/publish-from-actions.sh
@@ -26,9 +26,7 @@
 
 set -e
 
-if [ -z "${BUILD_DIR:-}" ]; then
-  source ./build_dir
-fi
+: "${BUILD_DIR:?BUILD_DIR must point to the site output to publish}"
 
 echo "#################################################"
 echo "Changing directory to 'BUILD_DIR' $BUILD_DIR ..."


### PR DESCRIPTION
Remove the obsolete build directory helper left over from the previous docs deployment flow and require the publish workflow to provide its build output explicitly.