### PR TITLE
Automatically select the browser language

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Spanish is enabled in `content/locales.json`. Its documentation is published at
 `/es-ES/docs/*`, and the Docusaurus language menu switches between English and
 Spanish versions of the current document.
 
+On an unprefixed page view, the combined static site uses a saved language-menu
+choice or selects a supported locale from the browser's preferences. The URL
+always identifies the language of the page being viewed.
+
 ## Translation guidelines
 
 Follow the repository-wide authoring and translation rules in

--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -12,6 +12,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import path from "node:path";
+import { renderLocalePreferenceScript } from "./locale-preference.mjs";
 
 const root = process.cwd();
 const docsSite = path.join(root, "docs-site/build");
@@ -40,6 +41,22 @@ function docsOutputRoot(locale) {
   return locale.default
     ? path.join(docsSite, "docs")
     : path.join(docsSite, localeOutputRoot(locale), "docs");
+}
+
+function combinedMarketingRouteFile(locale, route) {
+  return path.join(combinedSite, localeOutputRoot(locale), route, "index.html");
+}
+
+async function injectLocalePreferenceScript(file) {
+  const contents = await readFile(file, "utf8");
+  assert.match(contents, /<\/head>/i, `HTML head is missing: ${path.relative(root, file)}`);
+  await writeFile(
+    file,
+    contents.replace(
+      /<\/head>/i,
+      '    <script src="/locale-preference.js"></script>\n  </head>',
+    ),
+  );
 }
 
 async function requirePath(target) {
@@ -311,6 +328,31 @@ await Promise.all(
     ),
   ),
 );
+
+const localizedHtmlFiles = new Set([
+  ...docsBefore.flatMap(({ locale, files }) =>
+    [...files.keys()]
+      .filter((relative) => relative.endsWith(".html"))
+      .map((relative) =>
+        path.join(
+          combinedSite,
+          locale.default ? "docs" : localeOutputRoot(locale),
+          locale.default ? relative : path.join("docs", relative),
+        ),
+      ),
+  ),
+  ...locales.flatMap((locale) =>
+    marketingRoutes.map((route) => combinedMarketingRouteFile(locale, route)),
+  ),
+]);
+
+await Promise.all([
+  writeFile(
+    path.join(combinedSite, "locale-preference.js"),
+    renderLocalePreferenceScript(locales, defaultLocale),
+  ),
+  ...[...localizedHtmlFiles].map(injectLocalePreferenceScript),
+]);
 
 const combinedStats = await stat(combinedSite);
 assert(combinedStats.isDirectory());

--- a/scripts/locale-preference.mjs
+++ b/scripts/locale-preference.mjs
@@ -1,0 +1,91 @@
+export function renderLocalePreferenceScript(locales, defaultLocale) {
+  const localeConfig = locales.map(({ code, pathPrefix }) => ({
+    code,
+    pathPrefix,
+  }));
+
+  return `(() => {
+  const locales = ${JSON.stringify(localeConfig)};
+  const defaultLocale = ${JSON.stringify(defaultLocale.code)};
+  const storageKey = "caprover.locale";
+
+  function findLocale(language) {
+    if (!language) return undefined;
+    const normalized = language.toLowerCase();
+    return (
+      locales.find((locale) => locale.code.toLowerCase() === normalized) ??
+      locales.find(
+        (locale) =>
+          locale.code.toLowerCase().split("-")[0] === normalized.split("-")[0],
+      )
+    );
+  }
+
+  function preferredBrowserLocale() {
+    const browserLanguages = navigator.languages?.length
+      ? navigator.languages
+      : [navigator.language];
+    for (const language of browserLanguages) {
+      const locale = findLocale(language);
+      if (locale) return locale;
+    }
+    return locales.find((locale) => locale.code === defaultLocale);
+  }
+
+  function readSavedLocale() {
+    try {
+      return findLocale(localStorage.getItem(storageKey));
+    } catch {
+      return undefined;
+    }
+  }
+
+  function saveLocale(locale) {
+    try {
+      localStorage.setItem(storageKey, locale.code);
+    } catch {
+      // Language detection still works when storage is unavailable.
+    }
+  }
+
+  function localeForPath(pathname) {
+    return (
+      locales.find(
+        (locale) =>
+          locale.pathPrefix &&
+          (pathname === locale.pathPrefix ||
+            pathname.startsWith(\`\${locale.pathPrefix}/\`)),
+      ) ?? locales.find((locale) => locale.code === defaultLocale)
+    );
+  }
+
+  const currentLocale = localeForPath(location.pathname);
+  if (currentLocale.code === defaultLocale) {
+    const preferredLocale = readSavedLocale() ?? preferredBrowserLocale();
+    if (preferredLocale && preferredLocale.code !== defaultLocale) {
+      saveLocale(preferredLocale);
+      location.replace(
+        \`\${preferredLocale.pathPrefix}\${location.pathname}\${location.search}\${location.hash}\`,
+      );
+      return;
+    }
+  }
+
+  document.addEventListener("click", (event) => {
+    const link = event.target?.closest?.("a[lang], a[hreflang]");
+    if (!link) return;
+    const selectedLocale = findLocale(
+      link.getAttribute("lang") ?? link.getAttribute("hreflang"),
+    );
+    if (!selectedLocale) return;
+    const destination = new URL(link.href, location.href);
+    if (
+      destination.origin === location.origin &&
+      localeForPath(destination.pathname).code === selectedLocale.code
+    ) {
+      saveLocale(selectedLocale);
+    }
+  });
+})();
+`;
+}

--- a/scripts/smoke-combined-site.mjs
+++ b/scripts/smoke-combined-site.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
+import vm from "node:vm";
 
 const siteRoot = path.resolve("build/combined-site");
 const locales = JSON.parse(
@@ -118,6 +119,7 @@ try {
     spanishDokkuComparison: `${origin}/es-ES${marketingRoutes.dokku.path}index.html`,
     dashboardImage: `${origin}/homepage-assets/caprover-dashboard.png`,
     nextAsset: `${origin}${nextAsset}`,
+    localePreference: `${origin}/locale-preference.js`,
     robots: `${origin}/robots.txt`,
   };
   const responses = Object.fromEntries(
@@ -139,11 +141,13 @@ try {
   const docs = await responses.docs.text();
   assert.match(docs, /Getting Started/i);
   assert.match(docs, /href=["']?\/es-ES\/docs\/get-started(?:["'\s>])/);
+  assert.match(docs, /src=["']\/locale-preference\.js["']/);
   const spanishDocs = await responses.spanishDocs.text();
   assert.match(spanishDocs, /<html lang=["']?es-ES(?:["'\s>])/);
   assert.match(spanishDocs, /Primeros pasos/);
   assert.match(spanishDocs, /Conceptos básicos/);
   assert.match(spanishDocs, /href=["']?\/docs\/get-started(?:["'\s>])/);
+  assert.match(spanishDocs, /src=["']\/locale-preference\.js["']/);
   const englishHomepageAlias = await responses.englishHomepageAlias.text();
   assert.match(englishHomepageAlias, /Deploy apps\./);
   assert.match(englishHomepageAlias, /rel=["']canonical["'][^>]+href=["']https:\/\/caprover\.com\/["']/);
@@ -153,6 +157,7 @@ try {
   assert.match(spanishHomepage, /<html lang=["']es-ES["']/);
   assert.match(spanishHomepage, /<main lang=["']es-ES["']/);
   assert.match(spanishHomepage, /rel=["']canonical["'][^>]+href=["']https:\/\/caprover\.com\/es-ES\/["']/);
+  assert.match(spanishHomepage, /src=["']\/locale-preference\.js["']/);
   const spanishComparisonPages = await Promise.all(
     [
       responses.spanishComparisonHub,
@@ -174,6 +179,103 @@ try {
     await responses.robots.text(),
     "User-agent: *\nAllow: /\nSitemap: https://caprover.com/sitemap.xml\n",
   );
+
+  const localePreferenceScript = await responses.localePreference.text();
+
+  function runLocalePreference({
+    pathname = "/",
+    search = "",
+    hash = "",
+    languages = [],
+    savedLocale,
+  } = {}) {
+    const storage = new Map();
+    if (savedLocale) storage.set("caprover.locale", savedLocale);
+    let redirect;
+    let clickListener;
+    const location = {
+      origin,
+      href: `${origin}${pathname}${search}${hash}`,
+      pathname,
+      search,
+      hash,
+      replace(destination) {
+        redirect = destination;
+      },
+    };
+    vm.runInNewContext(localePreferenceScript, {
+      URL,
+      document: {
+        addEventListener(type, listener) {
+          if (type === "click") clickListener = listener;
+        },
+      },
+      localStorage: {
+        getItem(key) {
+          return storage.get(key) ?? null;
+        },
+        setItem(key, value) {
+          storage.set(key, value);
+        },
+      },
+      location,
+      navigator: {
+        language: languages[0],
+        languages,
+      },
+    });
+    return { clickListener, redirect, storage };
+  }
+
+  const spanishBrowser = runLocalePreference({
+    pathname: "/docs/get-started",
+    search: "?source=test",
+    hash: "#install",
+    languages: ["es-MX", "en-US"],
+  });
+  assert.equal(
+    spanishBrowser.redirect,
+    "/es-ES/docs/get-started?source=test#install",
+  );
+  assert.equal(spanishBrowser.storage.get("caprover.locale"), "es-ES");
+
+  assert.equal(runLocalePreference({ languages: ["fr-FR"] }).redirect, undefined);
+  assert.equal(
+    runLocalePreference({ languages: ["es-ES"], savedLocale: "en" }).redirect,
+    undefined,
+  );
+  assert.equal(
+    runLocalePreference({
+      pathname: "/compare",
+      languages: ["en-US"],
+      savedLocale: "es-ES",
+    }).redirect,
+    "/es-ES/compare",
+  );
+  assert.equal(
+    runLocalePreference({ pathname: "/es-ES/", savedLocale: "en" }).redirect,
+    undefined,
+  );
+
+  const manualSelection = runLocalePreference({
+    pathname: "/es-ES/docs/get-started",
+    languages: ["es-ES"],
+    savedLocale: "es-ES",
+  });
+  assert(manualSelection.clickListener, "Locale selection listener is missing");
+  manualSelection.clickListener({
+    target: {
+      closest() {
+        return {
+          href: `${origin}/docs/get-started`,
+          getAttribute(name) {
+            return name === "lang" ? "en" : null;
+          },
+        };
+      },
+    },
+  });
+  assert.equal(manualSelection.storage.get("caprover.locale"), "en");
 
   function docsStylesheet(html) {
     const match = html.match(


### PR DESCRIPTION
## Summary

- Select a supported locale from a saved choice or browser preferences on unprefixed routes
- Preserve manual language choices across the marketing and documentation sites
- Cover regional matching, redirects, and language switching in the combined-site smoke test

## Testing

- Marketing lint, formatting, build, and static-export tests
- Docusaurus bilingual production build
- Combined-site composition and HTTP smoke test