### PR TITLE
Fix localized sitemap generation

### DIFF
--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -229,21 +229,37 @@ const [docsSitemaps, marketingSitemap] = await Promise.all([
   ),
   readFile(path.join(marketingSite, "sitemap.xml"), "utf8"),
 ]);
-const marketingUrls = (marketingSitemap.match(/<url>[\s\S]*?<\/url>/g) ?? []).filter(
-  (entry) => !entry.includes("<loc>https://caprover.com/</loc>"),
-);
+const marketingUrls =
+  marketingSitemap.match(/<url>[\s\S]*?<\/url>/g) ?? [];
 assert.equal(
   marketingUrls.length,
-  locales.length * marketingRoutes.length - 1,
+  locales.length * marketingRoutes.length,
   "Marketing sitemap is missing localized URLs",
 );
 const docsUrls = docsSitemaps.flatMap(
   (sitemap) => sitemap.match(/<url>[\s\S]*?<\/url>/g) ?? [],
 );
 const allUrls = [...new Set([...docsUrls, ...marketingUrls])];
+const sitemapLocations = allUrls.flatMap((entry) =>
+  [...entry.matchAll(/<loc>([^<]+)<\/loc>/g)].map(([, location]) => location),
+);
+assert.equal(
+  sitemapLocations.length,
+  new Set(sitemapLocations).size,
+  "Combined sitemap contains duplicate URLs",
+);
+for (const locale of locales) {
+  for (const route of marketingRoutes) {
+    const expectedUrl = `https://caprover.com${locale.pathPrefix}/${route ? `${route}/` : ""}`;
+    assert(
+      sitemapLocations.includes(expectedUrl),
+      `Combined sitemap is missing: ${expectedUrl}`,
+    );
+  }
+}
 await writeFile(
   path.join(combinedSite, "sitemap.xml"),
-  `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${allUrls.join("\n")}\n</urlset>\n`,
+  `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">\n${allUrls.join("\n")}\n</urlset>\n`,
 );
 await writeFile(path.join(combinedSite, ".nojekyll"), "");
 await requirePath(path.join(combinedSite, ".nojekyll"));

--- a/scripts/compose-site.mjs
+++ b/scripts/compose-site.mjs
@@ -239,7 +239,7 @@ assert.equal(
 const docsUrls = docsSitemaps.flatMap(
   (sitemap) => sitemap.match(/<url>[\s\S]*?<\/url>/g) ?? [],
 );
-const allUrls = [...new Set([...docsUrls, ...marketingUrls])];
+const allUrls = [...docsUrls, ...marketingUrls];
 const sitemapLocations = allUrls.flatMap((entry) =>
   [...entry.matchAll(/<loc>([^<]+)<\/loc>/g)].map(([, location]) => location),
 );

--- a/scripts/smoke-combined-site.mjs
+++ b/scripts/smoke-combined-site.mjs
@@ -19,6 +19,7 @@ const contentTypes = new Map([
   [".js", "text/javascript"],
   [".png", "image/png"],
   [".woff2", "font/woff2"],
+  [".xml", "application/xml"],
 ]);
 
 const server = createServer(async (request, response) => {
@@ -121,6 +122,7 @@ try {
     nextAsset: `${origin}${nextAsset}`,
     localePreference: `${origin}/locale-preference.js`,
     robots: `${origin}/robots.txt`,
+    sitemap: `${origin}/sitemap.xml`,
   };
   const responses = Object.fromEntries(
     await Promise.all(
@@ -179,6 +181,42 @@ try {
     await responses.robots.text(),
     "User-agent: *\nAllow: /\nSitemap: https://caprover.com/sitemap.xml\n",
   );
+
+  const sitemap = await responses.sitemap.text();
+  assert.match(sitemap, /^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+  assert.match(
+    sitemap,
+    /<urlset xmlns="http:\/\/www\.sitemaps\.org\/schemas\/sitemap\/0\.9" xmlns:xhtml="http:\/\/www\.w3\.org\/1999\/xhtml">/,
+  );
+  assert.match(sitemap, /<\/urlset>\s*$/);
+  assert.equal(
+    (sitemap.match(/<url>/g) ?? []).length,
+    (sitemap.match(/<\/url>/g) ?? []).length,
+    "Sitemap URL elements are unbalanced",
+  );
+  const sitemapLocations = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+    ([, location]) => location,
+  );
+  assert.equal(
+    sitemapLocations.length,
+    new Set(sitemapLocations).size,
+    "Sitemap contains duplicate canonical URLs",
+  );
+  for (const locale of locales) {
+    const expectedUrls = [
+      ...Object.values(marketingRoutes).map(
+        (route) => `https://caprover.com${locale.pathPrefix}${route.path}`,
+      ),
+      `https://caprover.com${locale.pathPrefix}/docs/get-started`,
+    ];
+    for (const expectedUrl of expectedUrls) {
+      assert.equal(
+        sitemapLocations.filter((location) => location === expectedUrl).length,
+        1,
+        `Sitemap must contain exactly one entry for ${expectedUrl}`,
+      );
+    }
+  }
 
   const localePreferenceScript = await responses.localePreference.text();
 


### PR DESCRIPTION
Fix the combined sitemap namespace and restore the canonical English homepage entry.

Add smoke coverage for sitemap structure, localized canonical URLs, and duplicate entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sitemap generation to preserve all marketing and localized routes.
  * Added validation to prevent duplicate or missing sitemap URLs.
  * Ensured generated sitemaps include the required XML and XHTML namespace declarations.

* **Tests**
  * Expanded sitemap checks to verify valid XML structure, unique URLs, balanced elements, and required marketing and documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->