### PR TITLE
Fix documentation edit links

### DIFF
--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -45,8 +45,8 @@ const config = {
           path: "../content/en/docs",
           routeBasePath: "docs",
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl:
-            "https://github.com/caprover/caprover-website/edit/master/content/en/docs/",
+          editUrl: ({ locale, docPath }) =>
+            `https://github.com/caprover/caprover-website/edit/master/content/${locale}/docs/${docPath}`,
           showLastUpdateAuthor: false,
           showLastUpdateTime: false,
         },

--- a/scripts/smoke-combined-site.mjs
+++ b/scripts/smoke-combined-site.mjs
@@ -95,6 +95,12 @@ try {
     );
     const localizedDocs = await docsResponse.text();
     assert(localizedDocs.includes(docsTitle), `${locale.code} documentation content is missing`);
+    const editUrl =
+      `https://github.com/caprover/caprover-website/edit/master/content/${locale.code}/docs/get-started.md`;
+    assert(
+      localizedDocs.includes(editUrl),
+      `${locale.code} documentation edit URL is incorrect`,
+    );
   }
 
   const homepageResponse = await fetch(`${origin}/`);


### PR DESCRIPTION
Fix localized documentation edit links after the Docusaurus 3 migration.

Add integration coverage for each enabled locale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub edit links in documentation now correctly reflect the current language and document location.
  * Improved documentation smoke tests to verify edit links for localized getting-started pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->